### PR TITLE
docs: sync stale content — release matrix order, ackoctl repo entry, plugins inventory

### DIFF
--- a/docs/docs/architecture/adr/2026-04-07-daily-release-pipeline.md
+++ b/docs/docs/architecture/adr/2026-04-07-daily-release-pipeline.md
@@ -12,7 +12,7 @@ last_updated: 2026-04-07
 
 ## 상태
 
-**Proposed**
+**Accepted**
 
 - 제안일: 2026-04-07
 - 관련 이슈: aerospike-ce-ecosystem/project-hub#46

--- a/docs/docs/architecture/components/plugins.mdx
+++ b/docs/docs/architecture/components/plugins.mdx
@@ -5,14 +5,14 @@ sidebar_position: 4
 scope: single-repo
 repos: [plugins]
 tags: [architecture, component-diagram, plugins]
-last_updated: 2026-03-29
+last_updated: 2026-05-15
 ---
 
 import FlowDiagram from '@site/src/components/diagrams/FlowDiagram';
 
 # Claude Code Plugins Component Diagram
 
-User → Agent → Plugin 계층의 최하단에서 ACKO 배포, aerospike-py API, 클러스터 디버깅을 가이드하는 5개 Skill과 1개 Agent입니다.
+User → Agent → Plugin 계층의 최하단에서 ACKO 배포·운영·디버깅, aerospike-py API, ackoctl CLI, 버그 리포팅을 가이드하는 9개 Skill입니다. (별도 Agent 없음 — 기존 `acko-cluster-debugger` Agent는 `acko-debugging` Skill로 강등됨)
 
 <FlowDiagram
   height={450}
@@ -20,10 +20,10 @@ User → Agent → Plugin 계층의 최하단에서 ACKO 배포, aerospike-py AP
   nodes={[
     { id: 'agent', label: 'Agent (Claude Code)', group: 'orange', position: { x: 280, y: 0 } },
 
-    { id: 'plugin-group', label: 'CE Ecosystem Plugin', icon: '🔌', group: 'orange', description: 'plugin.json v1.0.0', width: 720, height: 200, position: { x: 15, y: 90 } },
-    { id: 'acko-skills', label: 'ACKO Skills', group: 'green', items: ['acko-deploy', 'acko-operations', 'acko-config-reference'], parent: 'plugin-group', position: { x: 20, y: 55 } },
+    { id: 'plugin-group', label: 'CE Ecosystem Plugin', icon: '🔌', group: 'orange', description: 'plugin.json — 9 skills', width: 720, height: 200, position: { x: 15, y: 90 } },
+    { id: 'acko-skills', label: 'ACKO Skills', group: 'green', items: ['acko-deploy', 'acko-operations', 'acko-config-reference', 'acko-debugging', 'acko-e2e-test'], parent: 'plugin-group', position: { x: 20, y: 55 } },
     { id: 'py-skills', label: 'Python Skills', group: 'purple', items: ['aerospike-py-api', 'aerospike-py-fastapi'], parent: 'plugin-group', position: { x: 260, y: 55 } },
-    { id: 'debugger', label: 'acko-cluster-debugger', group: 'blue', items: ['Agent', '39 issue-fix mappings'], parent: 'plugin-group', position: { x: 480, y: 55 } },
+    { id: 'tooling-skills', label: 'Tooling Skills', group: 'blue', items: ['ackoctl', 'bug-reporter'], parent: 'plugin-group', position: { x: 480, y: 55 } },
 
     { id: 'acko', label: 'ACKO', group: 'grey', position: { x: 80, y: 360 } },
     { id: 'aspy', label: 'aerospike-py', group: 'grey', position: { x: 330, y: 360 } },
@@ -34,7 +34,7 @@ User → Agent → Plugin 계층의 최하단에서 ACKO 배포, aerospike-py AP
     { from: 'acko-skills', to: 'acko', label: 'guides', animated: true },
     { from: 'py-skills', to: 'aspy', label: 'guides', animated: true },
     { from: 'py-skills', to: 'cm', label: 'FastAPI 패턴', dashed: true },
-    { from: 'debugger', to: 'acko', label: 'debugs', animated: true },
+    { from: 'tooling-skills', to: 'cm', label: 'ackoctl → CM', animated: true },
   ]}
 />
 
@@ -43,6 +43,9 @@ User → Agent → Plugin 계층의 최하단에서 ACKO 배포, aerospike-py AP
 | **Skill** | `acko-deploy` | ACKO | K8s 배포 YAML 가이드, CE 제약 반영 |
 | **Skill** | `acko-operations` | ACKO | 스케일링, 업그레이드, 재시작, 트러블슈팅 |
 | **Skill** | `acko-config-reference` | ACKO | CE 8.1 설정 파라미터 레퍼런스 |
+| **Skill** | `acko-debugging` | ACKO | 6단계 진단 절차 기반 클러스터 디버깅 (기존 `acko-cluster-debugger` Agent를 Skill로 강등) |
+| **Skill** | `acko-e2e-test` | ACKO | Kind/로컬 클러스터 E2E 테스트 시나리오 가이드 |
 | **Skill** | `aerospike-py-api` | aerospike-py | CRUD, batch, CDT, Expression API 가이드 |
 | **Skill** | `aerospike-py-fastapi` | aerospike-py, CM | AsyncClient + FastAPI 통합 패턴 |
-| **Agent** | `acko-cluster-debugger` | ACKO | kubectl 기반 자율 디버깅, 39개 이슈-수정 매핑 |
+| **Skill** | `ackoctl` | ackoctl, CM | ackoctl CLI로 cluster-manager 제어 가이드 |
+| **Skill** | `bug-reporter` | ecosystem | 증상 기반으로 올바른 레포에 버그 이슈 라우팅 |

--- a/docs/docs/history/releases/release-matrix.md
+++ b/docs/docs/history/releases/release-matrix.md
@@ -13,7 +13,7 @@ tags:
   - compatibility
   - matrix
   - versioning
-last_updated: 2026-04-07
+last_updated: 2026-05-15
 ---
 
 # Release Compatibility Matrix
@@ -78,8 +78,8 @@ Aerospike CE Ecosystem 각 프로젝트 간 릴리스 호환성 매트릭스입�
 | v0.2.0~v0.2.3 | 2026-02-28~03-03 | Initial release, basic CRUD UI |
 | v0.3.0~v0.3.2 | 2026-03-04~10 | ACKO integration, K8s cluster management UI |
 | v0.3.4~v0.3.7 | 2026-03-10~16 | Template scheduling, monitoring |
-| v0.4.0 | 2026-03-18 | Feature updates aligned with ACKO v0.1.4+ |
 | v0.3.8 | 2026-03-30 | Stability fixes (backport) |
+| v0.4.0 | 2026-03-18 | Feature updates aligned with ACKO v0.1.4+ |
 | v0.5.0~v0.5.2 | 2026-04-02~03 | SSE real-time streaming, parallel health checks, per-connection locks |
 | v0.6.0~v0.6.1 | 2026-04-03 | K8s server-side pagination, security headers, virtual scrolling |
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -7,6 +7,7 @@ repos:
   - aerospike-py
   - aerospike-ce-kubernetes-operator
   - aerospike-cluster-manager
+  - ackoctl
   - aerospike-ce-ecosystem-plugins
   - project-hub
 tags:
@@ -18,7 +19,7 @@ last_updated: 2026-03-29
 
 # Aerospike CE Ecosystem Hub
 
-Aerospike CE Ecosystem Hub는 4개의 핵심 레포지토리를 중앙에서 관리하는 프로젝트 허브입니다. 크로스-레포 이슈 추적, 아키텍처 결정, 로드맵 관리, 릴리스 조율 등 생태계 전반의 협업을 이곳에서 수행합니다.
+Aerospike CE Ecosystem Hub는 5개의 핵심 레포지토리를 중앙에서 관리하는 프로젝트 허브입니다. 크로스-레포 이슈 추적, 아키텍처 결정, 로드맵 관리, 릴리스 조율 등 생태계 전반의 협업을 이곳에서 수행합니다.
 
 ## 핵심 레포지토리
 
@@ -27,6 +28,7 @@ Aerospike CE Ecosystem Hub는 4개의 핵심 레포지토리를 중앙에서 관
 | [aerospike-py](https://github.com/aerospike-ce-ecosystem/aerospike-py) | Aerospike Python 클라이언트 | Rust/PyO3 기반 고성능 async Python 클라이언트 |
 | [ACKO](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator) | Aerospike CE Kubernetes Operator | Go 기반 Kubernetes Operator로 Aerospike 클러스터 자동 배포/관리 |
 | [cluster-manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager) | Aerospike Cluster Manager | Python/TypeScript 기반 웹 UI로 클러스터 모니터링 및 관리 |
+| [ackoctl](https://github.com/aerospike-ce-ecosystem/ackoctl) | Aerospike Cluster Manager CLI | Go + cobra 기반 CLI로 cluster-manager 제어 (connection/cluster/k8s/record/set/query/index) |
 | [plugins](https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins) | Claude Code Plugins | 생태계 전용 Claude Code 플러그인 (skills, hooks, commands) |
 
 ## 문서 구성


### PR DESCRIPTION
## Summary

Review-driven fixes for stale documentation content. All changes verified against the actual repos and a clean `npm run build` (Docusaurus `onBrokenLinks: 'throw'`).

## Fixes

1. **`release-matrix.md`** — In the Cluster Manager table, `v0.3.8` was listed after `v0.4.0`. Reordered to version-ascending order (v0.3.8 before v0.4.0) to match the rest of the table. Bumped `last_updated` frontmatter to `2026-05-15`.

2. **`intro.md`** — Said "4개의 핵심 레포지토리" but omitted `ackoctl`. Added the `ackoctl` row (Go + cobra CLI for cluster-manager) to the repo table, added it to frontmatter `repos`, and corrected the count to 5.

3. **`components/plugins.mdx`** — Was stale: described "5 Skills + 1 Agent" including an `acko-cluster-debugger` agent. Updated to reflect the current reality: **9 skills, no agent**. The agent was demoted to the `acko-debugging` skill; `acko-e2e-test`, `ackoctl`, and `bug-reporter` skills were added. Updated the FlowDiagram nodes and the skill table. Verified against `aerospike-ce-ecosystem-plugins/skills/` (9 directories, no `agents/` dir).

4. **ADR-0039 (`2026-04-07-daily-release-pipeline.md`)** — Status was `**Proposed**` but the daily-release pipeline is live. Confirmed `daily-release.yml` exists in the plugins repo. Changed status to `**Accepted**`.

## Verification

- `npm install` + `npm run build` pass with zero broken links/anchors (only a benign third-party `vscode-languageserver-types` webpack warning, unrelated to these edits).

## Follow-ups (not in this PR)

These are large, judgment-heavy changes that should be a dedicated renumbering PR:

- **ADR number collisions** — 30 of 49 ADRs share `sidebar_position` / ADR-XXXX numbers with another ADR. Needs a careful, deliberate renumbering pass.
- **`adr-index.mdx` omits 33 ADRs** — the ADR index is significantly out of date and should be regenerated as part of the same renumbering effort.