### PR TITLE
fix(adr): resolve duplicate ADR-0039 numbering across ten 2026-04-07 ADRs

### DIFF
--- a/docs/docs/architecture/adr-index.mdx
+++ b/docs/docs/architecture/adr-index.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 scope: ecosystem
 repos: [aerospike-py, acko, cluster-manager, plugins]
 tags: [adr, architecture, decision-record]
-last_updated: 2026-03-29
+last_updated: 2026-05-23
 ---
 
 import Tabs from '@theme/Tabs';
@@ -80,12 +80,46 @@ Architecture Decision Record(ADR)는 프로젝트의 중요한 아키텍처 결�
 | [ADR-0008](./adr/2026-03-10-issueops-ci-workflow.md) | IssueOps 기반 CI 워크플로우 | 2026-03-10 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> |
 | [ADR-0009](./adr/2026-03-20-unified-batch-records-api.md) | Unified BatchRecords API | 2026-03-20 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> |
 | [ADR-0010](./adr/2026-02-05-observability-stack.md) | 3-Layer Observability Stack | 2026-02-05 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> |
-| [ADR-0011](./adr/2026-03-10-crd-rename-aerospikecluster.md) | CRD Rename: AerospikeCluster | 2026-03-10 | <Status status="Accepted" /> | <Repo name="acko" /> |
-| [ADR-0012](./adr/2026-02-20-pod-readiness-gates.md) | Pod Readiness Gates | 2026-02-20 | <Status status="Accepted" /> | <Repo name="acko" /> |
-| [ADR-0013](./adr/2026-03-01-reconciliation-circuit-breaker.md) | Reconciliation Circuit Breaker | 2026-03-01 | <Status status="Accepted" /> | <Repo name="acko" /> |
-| [ADR-0014](./adr/2026-02-10-postgresql-migration.md) | SQLite → PostgreSQL Migration | 2026-02-10 | <Status status="Accepted" /> | <Repo name="cluster-manager" /> |
-| [ADR-0015](./adr/2026-03-05-asinfo-health-checks.md) | asinfo 기반 Health Check | 2026-03-05 | <Status status="Accepted" /> | <Repo name="acko" /> |
+| [ADR-0011](./adr/2026-03-10-crd-rename-aerospikecluster.md) | CRD 이름 AerospikeCluster로 변경 | 2026-03-10 | <Status status="Accepted" /> | <Repo name="acko" /> |
+| [ADR-0012](./adr/2026-02-20-pod-readiness-gates.md) | Pod Readiness Gates 도입 | 2026-02-20 | <Status status="Accepted" /> | <Repo name="acko" /> |
+| [ADR-0013](./adr/2026-03-01-reconciliation-circuit-breaker.md) | Reconciliation Circuit Breaker 도입 | 2026-03-01 | <Status status="Accepted" /> | <Repo name="acko" /> |
+| [ADR-0014](./adr/2026-02-10-postgresql-migration.md) | SQLite에서 PostgreSQL로 마이그레이션 | 2026-02-10 | <Status status="Accepted" /> | <Repo name="cluster-manager" /> |
+| [ADR-0015](./adr/2026-03-05-asinfo-health-checks.md) | asinfo 기반 Health Check 도입 | 2026-03-05 | <Status status="Accepted" /> | <Repo name="acko" /> |
+| [ADR-0016](./adr/2026-03-29-sse-event-streaming.md) | SSE 기반 실시간 이벤트 스트리밍 도입 | 2026-03-29 | <Status status="Proposed" /> | <Repo name="cluster-manager" /> |
+| [ADR-0017](./adr/2026-03-30-batch-retry-jitter-backoff.md) | Batch Retry에 Jitter 기반 Exponential Backoff 도입 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> |
+| [ADR-0018](./adr/2026-03-30-circuit-breaker-adaptive-threshold.md) | ACKO Reconciliation Circuit Breaker 임계값 자동 조정 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="acko" /> |
+| [ADR-0019](./adr/2026-03-30-codegen-type-sync.md) | Cluster Manager Backend↔Frontend 타입 동기화 자동화 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="cluster-manager" /> |
+| [ADR-0020](./adr/2026-03-30-virtual-scroll-record-browser.md) | Cluster Manager 레코드 브라우저 가상 스크롤 도입 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="cluster-manager" /> |
+| [ADR-0021](./adr/2026-03-30-graceful-cancellation.md) | Cluster Manager Backend 비동기 연산의 Graceful Cancellation | 2026-03-30 | <Status status="Proposed" /> | <Repo name="cluster-manager" /> |
+| [ADR-0022](./adr/2026-03-30-k8s-server-side-pagination.md) | K8s API Server-Side Pagination 및 Namespace Filtering | 2026-03-30 | <Status status="Proposed" /> | <Repo name="cluster-manager" /> |
+| [ADR-0023](./adr/2026-03-30-pause-resume-status-condition.md) | ACKO Pause/Resume 상태 전환 시 Status Condition 정합성 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="acko" /> |
+| [ADR-0024](./adr/2026-03-30-tokio-worker-autotuning.md) | aerospike-py Tokio Worker Thread 자동 튜닝 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> |
+| [ADR-0025](./adr/2026-03-30-info-batch-aggregation.md) | Aerospike Info 명령 배치 집계로 Overview 응답 단축 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="cluster-manager" /> |
+| [ADR-0026](./adr/2026-03-30-record-count-accuracy.md) | Cluster Manager 레코드 카운트 정확도 개선 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="cluster-manager" /> <Repo name="plugins" /> |
+| [ADR-0027](./adr/2026-03-30-structured-result-code.md) | aerospike-py 구조화된 에러 코드(result_code) 체계 도입 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
+| [ADR-0028](./adr/2026-03-30-validation-error-circuit-breaker.md) | ACKO ValidationError 기반 영구/일시적 오류 분류 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="acko" /> <Repo name="plugins" /> |
+| [ADR-0029](./adr/2026-03-30-asyncclient-connect-leak.md) | AsyncClient 동시 connect() 연결 누수 방지 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> |
+| [ADR-0030](./adr/2026-03-30-auth-security-headers.md) | Cluster Manager API 인증/인가 및 보안 헤더 강화 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="cluster-manager" /> |
+| [ADR-0031](./adr/2026-03-30-clientmanager-per-connection-lock.md) | ClientManager 동시성 결함 및 per-connection lock 도입 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="cluster-manager" /> <Repo name="aerospike-py" /> |
+| [ADR-0032](./adr/2026-03-30-dynamic-config-transaction.md) | ACKO Dynamic Config 부분 적용 방지 트랜잭션 보장 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="acko" /> |
+| [ADR-0033](./adr/2026-03-30-frontend-resource-leak-prevention.md) | Cluster Manager Frontend 리소스 누수 방지 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="cluster-manager" /> |
+| [ADR-0034](./adr/2026-03-30-health-check-parallel.md) | Cluster Manager Health Check 병렬화 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="cluster-manager" /> |
+| [ADR-0035](./adr/2026-03-30-pod-readiness-watch.md) | ACKO Pod Readiness Watch 전환 및 Status Enrichment 병렬화 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="acko" /> |
+| [ADR-0036](./adr/2026-03-30-webhook-validation-enhancement.md) | ACKO Webhook Validation 강화 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="acko" /> |
 | [ADR-0038](./adr/2026-04-05-external-network-access.md) | 외부 네트워크 접근 — Per-pod LB/NodePort | 2026-04-05 | <Status status="Accepted" /> | <Repo name="acko" /> |
+| [ADR-0039](./adr/2026-04-07-skill-impact-review-pipeline.md) | Skill Impact Review 파이프라인 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
+| [ADR-0040](./adr/2026-05-05-multi-cluster-topology-and-keycloak-oidc.md) | Multi-Cluster Topology and Keycloak OIDC | 2026-05-05 | <Status status="Accepted" /> | <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
+| [ADR-0041](./adr/2026-05-07-mcp-federation-gateway.md) | MCP Federation Gateway | 2026-05-07 | <Status status="Proposed" /> | <Repo name="cluster-manager" /> |
+| [ADR-0042](./adr/2026-05-21-acko-observability-otel-export.md) | ACKO·Cluster Manager OpenTelemetry Export 통합 | 2026-05-21 | <Status status="Accepted" /> | <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="aerospike-py" /> |
+| [ADR-0043](./adr/2026-04-07-ci-workflow-suite-standardization.md) | 에코시스템 통합 CI 워크플로우 스위트 표준화 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
+| [ADR-0044](./adr/2026-04-07-acko-e2e-expansion-strategy.md) | ACKO E2E 테스트 확장 전략 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="acko" /> |
+| [ADR-0045](./adr/2026-04-07-helm-chart-oci-dual-chart.md) | ACKO Helm Chart 버전 관리 체계 — OCI 이중 Chart | 2026-04-07 | <Status status="Proposed" /> | <Repo name="acko" /> |
+| [ADR-0046](./adr/2026-04-07-otel-tracing-integration.md) | OpenTelemetry Tracing 완전 통합 및 에코시스템 전파 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="cluster-manager" /> |
+| [ADR-0047](./adr/2026-04-07-numpy-batch-memory-model.md) | NumPy Batch 연산 인터페이스 확정 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> |
+| [ADR-0048](./adr/2026-04-07-record-browser-perf-strategy.md) | Record 브라우저 대용량 데이터 통합 성능 전략 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="cluster-manager" /> |
+| [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
+| [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
+| [ADR-0051](./adr/2026-04-07-daily-release-pipeline.md) | 에코시스템 일일 자동 릴리스 파이프라인 | 2026-04-07 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
 
   </TabItem>
   <TabItem value="aerospike-py" label="aerospike-py">
@@ -98,6 +132,19 @@ Architecture Decision Record(ADR)는 프로젝트의 중요한 아키텍처 결�
 | [ADR-0008](./adr/2026-03-10-issueops-ci-workflow.md) | IssueOps 기반 CI 워크플로우 | 2026-03-10 | <Status status="Accepted" /> |
 | [ADR-0009](./adr/2026-03-20-unified-batch-records-api.md) | Unified BatchRecords API | 2026-03-20 | <Status status="Accepted" /> |
 | [ADR-0010](./adr/2026-02-05-observability-stack.md) | 3-Layer Observability Stack | 2026-02-05 | <Status status="Accepted" /> |
+| [ADR-0017](./adr/2026-03-30-batch-retry-jitter-backoff.md) | Batch Retry에 Jitter 기반 Exponential Backoff 도입 | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0024](./adr/2026-03-30-tokio-worker-autotuning.md) | aerospike-py Tokio Worker Thread 자동 튜닝 | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0027](./adr/2026-03-30-structured-result-code.md) | 구조화된 에러 코드(result_code) 체계 도입 | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0029](./adr/2026-03-30-asyncclient-connect-leak.md) | AsyncClient 동시 connect() 연결 누수 방지 | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0031](./adr/2026-03-30-clientmanager-per-connection-lock.md) | ClientManager 동시성 결함 및 per-connection lock | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0039](./adr/2026-04-07-skill-impact-review-pipeline.md) | Skill Impact Review 파이프라인 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0042](./adr/2026-05-21-acko-observability-otel-export.md) | ACKO·Cluster Manager OpenTelemetry Export 통합 | 2026-05-21 | <Status status="Accepted" /> |
+| [ADR-0043](./adr/2026-04-07-ci-workflow-suite-standardization.md) | 에코시스템 통합 CI 워크플로우 스위트 표준화 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0046](./adr/2026-04-07-otel-tracing-integration.md) | OpenTelemetry Tracing 완전 통합 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0047](./adr/2026-04-07-numpy-batch-memory-model.md) | NumPy Batch 연산 인터페이스 확정 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0051](./adr/2026-04-07-daily-release-pipeline.md) | 에코시스템 일일 자동 릴리스 파이프라인 | 2026-04-07 | <Status status="Accepted" /> |
 
   </TabItem>
   <TabItem value="acko" label="ACKO">
@@ -108,11 +155,26 @@ Architecture Decision Record(ADR)는 프로젝트의 중요한 아키텍처 결�
 | [ADR-0003](./adr/2026-02-01-podman-over-docker.md) | Docker 대신 Podman 선택 | 2026-02-01 | <Status status="Accepted" /> |
 | [ADR-0007](./adr/2026-03-12-cluster-scoped-template.md) | Cluster-scoped AerospikeClusterTemplate | 2026-03-12 | <Status status="Accepted" /> |
 | [ADR-0008](./adr/2026-03-10-issueops-ci-workflow.md) | IssueOps 기반 CI 워크플로우 | 2026-03-10 | <Status status="Accepted" /> |
-| [ADR-0011](./adr/2026-03-10-crd-rename-aerospikecluster.md) | CRD Rename: AerospikeCluster | 2026-03-10 | <Status status="Accepted" /> |
-| [ADR-0012](./adr/2026-02-20-pod-readiness-gates.md) | Pod Readiness Gates | 2026-02-20 | <Status status="Accepted" /> |
-| [ADR-0013](./adr/2026-03-01-reconciliation-circuit-breaker.md) | Reconciliation Circuit Breaker | 2026-03-01 | <Status status="Accepted" /> |
-| [ADR-0015](./adr/2026-03-05-asinfo-health-checks.md) | asinfo 기반 Health Check | 2026-03-05 | <Status status="Accepted" /> |
+| [ADR-0011](./adr/2026-03-10-crd-rename-aerospikecluster.md) | CRD 이름 AerospikeCluster로 변경 | 2026-03-10 | <Status status="Accepted" /> |
+| [ADR-0012](./adr/2026-02-20-pod-readiness-gates.md) | Pod Readiness Gates 도입 | 2026-02-20 | <Status status="Accepted" /> |
+| [ADR-0013](./adr/2026-03-01-reconciliation-circuit-breaker.md) | Reconciliation Circuit Breaker 도입 | 2026-03-01 | <Status status="Accepted" /> |
+| [ADR-0015](./adr/2026-03-05-asinfo-health-checks.md) | asinfo 기반 Health Check 도입 | 2026-03-05 | <Status status="Accepted" /> |
+| [ADR-0018](./adr/2026-03-30-circuit-breaker-adaptive-threshold.md) | ACKO Circuit Breaker 임계값 자동 조정 | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0023](./adr/2026-03-30-pause-resume-status-condition.md) | ACKO Pause/Resume Status Condition 정합성 | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0028](./adr/2026-03-30-validation-error-circuit-breaker.md) | ACKO ValidationError 기반 오류 분류 | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0032](./adr/2026-03-30-dynamic-config-transaction.md) | ACKO Dynamic Config 트랜잭션 보장 | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0035](./adr/2026-03-30-pod-readiness-watch.md) | ACKO Pod Readiness Watch 전환 | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0036](./adr/2026-03-30-webhook-validation-enhancement.md) | ACKO Webhook Validation 강화 | 2026-03-30 | <Status status="Proposed" /> |
 | [ADR-0038](./adr/2026-04-05-external-network-access.md) | 외부 네트워크 접근 — Per-pod LB/NodePort | 2026-04-05 | <Status status="Accepted" /> |
+| [ADR-0039](./adr/2026-04-07-skill-impact-review-pipeline.md) | Skill Impact Review 파이프라인 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0040](./adr/2026-05-05-multi-cluster-topology-and-keycloak-oidc.md) | Multi-Cluster Topology and Keycloak OIDC | 2026-05-05 | <Status status="Accepted" /> |
+| [ADR-0042](./adr/2026-05-21-acko-observability-otel-export.md) | ACKO·Cluster Manager OpenTelemetry Export 통합 | 2026-05-21 | <Status status="Accepted" /> |
+| [ADR-0043](./adr/2026-04-07-ci-workflow-suite-standardization.md) | 에코시스템 통합 CI 워크플로우 스위트 표준화 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0044](./adr/2026-04-07-acko-e2e-expansion-strategy.md) | ACKO E2E 테스트 확장 전략 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0045](./adr/2026-04-07-helm-chart-oci-dual-chart.md) | ACKO Helm Chart 버전 관리 체계 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0051](./adr/2026-04-07-daily-release-pipeline.md) | 에코시스템 일일 자동 릴리스 파이프라인 | 2026-04-07 | <Status status="Accepted" /> |
 
   </TabItem>
   <TabItem value="cluster-manager" label="Cluster Manager">
@@ -122,7 +184,27 @@ Architecture Decision Record(ADR)는 프로젝트의 중요한 아키텍처 결�
 | [ADR-0003](./adr/2026-02-01-podman-over-docker.md) | Docker 대신 Podman 선택 | 2026-02-01 | <Status status="Accepted" /> |
 | [ADR-0005](./adr/2026-02-25-daisyui-removal.md) | DaisyUI 제거 및 Pure Tailwind CSS 4 전환 | 2026-02-25 | <Status status="Accepted" /> |
 | [ADR-0008](./adr/2026-03-10-issueops-ci-workflow.md) | IssueOps 기반 CI 워크플로우 | 2026-03-10 | <Status status="Accepted" /> |
-| [ADR-0014](./adr/2026-02-10-postgresql-migration.md) | SQLite → PostgreSQL Migration | 2026-02-10 | <Status status="Accepted" /> |
+| [ADR-0014](./adr/2026-02-10-postgresql-migration.md) | SQLite에서 PostgreSQL로 마이그레이션 | 2026-02-10 | <Status status="Accepted" /> |
+| [ADR-0016](./adr/2026-03-29-sse-event-streaming.md) | SSE 기반 실시간 이벤트 스트리밍 도입 | 2026-03-29 | <Status status="Proposed" /> |
+| [ADR-0019](./adr/2026-03-30-codegen-type-sync.md) | Backend↔Frontend 타입 동기화 자동화 | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0020](./adr/2026-03-30-virtual-scroll-record-browser.md) | 레코드 브라우저 가상 스크롤 도입 | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0021](./adr/2026-03-30-graceful-cancellation.md) | Backend 비동기 연산의 Graceful Cancellation | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0022](./adr/2026-03-30-k8s-server-side-pagination.md) | K8s API Server-Side Pagination | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0025](./adr/2026-03-30-info-batch-aggregation.md) | Aerospike Info 명령 배치 집계 | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0026](./adr/2026-03-30-record-count-accuracy.md) | 레코드 카운트 정확도 개선 | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0030](./adr/2026-03-30-auth-security-headers.md) | API 인증/인가 및 보안 헤더 강화 | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0033](./adr/2026-03-30-frontend-resource-leak-prevention.md) | Frontend 리소스 누수 방지 | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0034](./adr/2026-03-30-health-check-parallel.md) | Health Check 병렬화 | 2026-03-30 | <Status status="Proposed" /> |
+| [ADR-0039](./adr/2026-04-07-skill-impact-review-pipeline.md) | Skill Impact Review 파이프라인 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0040](./adr/2026-05-05-multi-cluster-topology-and-keycloak-oidc.md) | Multi-Cluster Topology and Keycloak OIDC | 2026-05-05 | <Status status="Accepted" /> |
+| [ADR-0041](./adr/2026-05-07-mcp-federation-gateway.md) | MCP Federation Gateway | 2026-05-07 | <Status status="Proposed" /> |
+| [ADR-0042](./adr/2026-05-21-acko-observability-otel-export.md) | ACKO·Cluster Manager OpenTelemetry Export 통합 | 2026-05-21 | <Status status="Accepted" /> |
+| [ADR-0043](./adr/2026-04-07-ci-workflow-suite-standardization.md) | 에코시스템 통합 CI 워크플로우 스위트 표준화 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0046](./adr/2026-04-07-otel-tracing-integration.md) | OpenTelemetry Tracing 완전 통합 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0048](./adr/2026-04-07-record-browser-perf-strategy.md) | Record 브라우저 대용량 데이터 성능 전략 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0051](./adr/2026-04-07-daily-release-pipeline.md) | 에코시스템 일일 자동 릴리스 파이프라인 | 2026-04-07 | <Status status="Accepted" /> |
 
   </TabItem>
 </Tabs>

--- a/docs/docs/architecture/adr/2026-04-07-acko-e2e-expansion-strategy.md
+++ b/docs/docs/architecture/adr/2026-04-07-acko-e2e-expansion-strategy.md
@@ -1,14 +1,14 @@
 ---
-title: "ADR-0039: ACKO E2E 테스트 확장 전략 — Kind 기반 운영 시나리오 테스트 프레임워크"
+title: "ADR-0044: ACKO E2E 테스트 확장 전략 — Kind 기반 운영 시나리오 테스트 프레임워크"
 description: ACKO의 E2E 테스트를 시나리오별 독립 테스트 스위트와 CI matrix 병렬 실행으로 확장하는 전략 결정.
-sidebar_position: 39
+sidebar_position: 44
 scope: single-repo
 repos: [acko]
 tags: [adr, acko, e2e, testing, kind, kubernetes, ci]
 last_updated: 2026-04-07
 ---
 
-# ADR-0039: ACKO E2E 테스트 확장 전략 — Kind 기반 운영 시나리오 테스트 프레임워크
+# ADR-0044: ACKO E2E 테스트 확장 전략 — Kind 기반 운영 시나리오 테스트 프레임워크
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-04-07-adr-lifecycle-automation.md
+++ b/docs/docs/architecture/adr/2026-04-07-adr-lifecycle-automation.md
@@ -1,14 +1,14 @@
 ---
-title: "ADR-0039: Project Hub ADR Lifecycle 자동화 아키텍처 — 리뷰/디스패치/상태 관리 3단계 자동화"
+title: "ADR-0049: Project Hub ADR Lifecycle 자동화 아키텍처 — 리뷰/디스패치/상태 관리 3단계 자동화"
 description: Project-hub의 ADR lifecycle을 AI 리뷰, cross-repo 디스패치, 상태 관리 3단계로 자동화하는 워크플로우 아키텍처를 문서화하고 표준화하는 결정.
-sidebar_position: 39
+sidebar_position: 49
 scope: ecosystem
 repos: [aerospike-py, acko, cluster-manager, plugins]
 tags: [adr, automation, issueops, ai-review, workflow, dispatch]
 last_updated: 2026-04-07
 ---
 
-# ADR-0039: Project Hub ADR Lifecycle 자동화 아키텍처 — 리뷰/디스패치/상태 관리 3단계 자동화
+# ADR-0049: Project Hub ADR Lifecycle 자동화 아키텍처 — 리뷰/디스패치/상태 관리 3단계 자동화
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-04-07-ci-workflow-suite-standardization.md
+++ b/docs/docs/architecture/adr/2026-04-07-ci-workflow-suite-standardization.md
@@ -1,14 +1,14 @@
 ---
-title: "ADR-0039: 에코시스템 통합 CI 워크플로우 스위트 표준화"
+title: "ADR-0043: 에코시스템 통합 CI 워크플로우 스위트 표준화"
 description: 에코시스템 5개 repo의 CI 워크플로우(agent-implement, pr-reviewer, issue-planner, daily-release, skill-impact-notify) 적용 범위를 표준화하고 공유 설정 관리 방식을 문서화하는 결정.
-sidebar_position: 39
+sidebar_position: 43
 scope: ecosystem
 repos: [aerospike-py, acko, cluster-manager, plugins]
 tags: [adr, ci, workflow, standardization, automation, claude-code-action]
 last_updated: 2026-04-07
 ---
 
-# ADR-0039: 에코시스템 통합 CI 워크플로우 스위트 표준화
+# ADR-0043: 에코시스템 통합 CI 워크플로우 스위트 표준화
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-04-07-daily-release-pipeline.md
+++ b/docs/docs/architecture/adr/2026-04-07-daily-release-pipeline.md
@@ -1,14 +1,14 @@
 ---
-title: "ADR-0039: 에코시스템 일일 자동 릴리스 파이프라인 — Conventional Commits 기반 SemVer 자동화"
+title: "ADR-0051: 에코시스템 일일 자동 릴리스 파이프라인 — Conventional Commits 기반 SemVer 자동화"
 description: 4개 core repo에서 매일 KST 09:00에 Conventional Commits 분석 기반 SemVer 자동 릴리스를 실행하는 daily-release 파이프라인의 아키텍처 결정 문서화.
-sidebar_position: 39
+sidebar_position: 51
 scope: ecosystem
 repos: [aerospike-py, acko, cluster-manager, plugins]
 tags: [adr, release, ci-cd, conventional-commits, semver, automation]
 last_updated: 2026-04-07
 ---
 
-# ADR-0039: 에코시스템 일일 자동 릴리스 파이프라인 — Conventional Commits 기반 SemVer 자동화
+# ADR-0051: 에코시스템 일일 자동 릴리스 파이프라인 — Conventional Commits 기반 SemVer 자동화
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-04-07-dependency-chain-merge-order.md
+++ b/docs/docs/architecture/adr/2026-04-07-dependency-chain-merge-order.md
@@ -1,14 +1,14 @@
 ---
-title: "ADR-0039: 에코시스템 의존성 체인 및 Merge 순서 원칙"
+title: "ADR-0050: 에코시스템 의존성 체인 및 Merge 순서 원칙"
 description: Cross-repo 변경 전파 시 의존성 체인 순서를 ADR로 공식화하고, 점진적 CI 검증을 도입하는 원칙을 정의합니다.
-sidebar_position: 39
+sidebar_position: 50
 scope: ecosystem
 repos: [aerospike-py, aerospike-ce-kubernetes-operator, aerospike-cluster-manager, aerospike-ce-ecosystem-plugins]
 tags: [adr, dependency-chain, merge-order, cross-repo, ci, release]
 last_updated: 2026-04-07
 ---
 
-# ADR-0039: 에코시스템 의존성 체인 및 Merge 순서 원칙
+# ADR-0050: 에코시스템 의존성 체인 및 Merge 순서 원칙
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-04-07-helm-chart-oci-dual-chart.md
+++ b/docs/docs/architecture/adr/2026-04-07-helm-chart-oci-dual-chart.md
@@ -1,14 +1,14 @@
 ---
-title: "ADR-0039: ACKO Helm Chart 버전 관리 체계 — OCI Registry 기반 CRD/Operator 이중 Chart 릴리스"
+title: "ADR-0045: ACKO Helm Chart 버전 관리 체계 — OCI Registry 기반 CRD/Operator 이중 Chart 릴리스"
 description: ACKO의 CRD와 Operator를 독립된 Helm chart로 분리하고 GHCR OCI Registry를 통해 배포하는 버전 관리 체계에 대한 아키텍처 결정.
-sidebar_position: 39
+sidebar_position: 45
 scope: single-repo
 repos: [acko]
 tags: [adr, acko, helm, oci, crd, versioning, kubernetes]
 last_updated: 2026-04-07
 ---
 
-# ADR-0039: ACKO Helm Chart 버전 관리 체계 — OCI Registry 기반 CRD/Operator 이중 Chart 릴리스
+# ADR-0045: ACKO Helm Chart 버전 관리 체계 — OCI Registry 기반 CRD/Operator 이중 Chart 릴리스
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-04-07-numpy-batch-memory-model.md
+++ b/docs/docs/architecture/adr/2026-04-07-numpy-batch-memory-model.md
@@ -1,14 +1,14 @@
 ---
-title: "ADR-0039: NumPy Batch 연산 인터페이스 확정 — Owned Arrays 기본 메모리 모델"
+title: "ADR-0047: NumPy Batch 연산 인터페이스 확정 — Owned Arrays 기본 메모리 모델"
 description: aerospike-py의 NumPy batch 연산에서 Owned Arrays를 기본 메모리 모델로 확정하고, API surface를 안정화하는 아키텍처 결정.
-sidebar_position: 39
+sidebar_position: 47
 scope: single-repo
 repos: [aerospike-py]
 tags: [adr, numpy, batch, memory-model, pyo3, aerospike-py, zero-copy]
 last_updated: 2026-04-07
 ---
 
-# ADR-0039: NumPy Batch 연산 인터페이스 확정 — Owned Arrays 기본 메모리 모델
+# ADR-0047: NumPy Batch 연산 인터페이스 확정 — Owned Arrays 기본 메모리 모델
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-04-07-otel-tracing-integration.md
+++ b/docs/docs/architecture/adr/2026-04-07-otel-tracing-integration.md
@@ -1,14 +1,14 @@
 ---
-title: "ADR-0039: OpenTelemetry Tracing 완전 통합 및 에코시스템 전파"
+title: "ADR-0046: OpenTelemetry Tracing 완전 통합 및 에코시스템 전파"
 description: aerospike-py의 OTel Tracing을 완성하고 cluster-manager까지 trace context를 전파하는 아키텍처 결정. Metrics는 Prometheus 유지.
-sidebar_position: 39
+sidebar_position: 46
 scope: ecosystem
 repos: [aerospike-py, cluster-manager]
 tags: [adr, opentelemetry, tracing, observability, prometheus]
 last_updated: 2026-04-07
 ---
 
-# ADR-0039: OpenTelemetry Tracing 완전 통합 및 에코시스템 전파
+# ADR-0046: OpenTelemetry Tracing 완전 통합 및 에코시스템 전파
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-04-07-record-browser-perf-strategy.md
+++ b/docs/docs/architecture/adr/2026-04-07-record-browser-perf-strategy.md
@@ -1,14 +1,14 @@
 ---
-title: "ADR-0039: Record 브라우저 대용량 데이터 통합 성능 전략 — Virtual Scroll + Pagination + Timeout 계층"
+title: "ADR-0048: Record 브라우저 대용량 데이터 통합 성능 전략 — Virtual Scroll + Pagination + Timeout 계층"
 description: Record 브라우저에서 대용량 데이터셋을 안정적으로 탐색하기 위해 가상 스크롤, cursor 기반 pagination, 3계층 timeout을 통합하는 상위 아키텍처 결정.
-sidebar_position: 39
+sidebar_position: 48
 scope: single-repo
 repos: [cluster-manager]
 tags: [adr, performance, virtual-scroll, pagination, timeout, cluster-manager, record-browser]
 last_updated: 2026-04-07
 ---
 
-# ADR-0039: Record 브라우저 대용량 데이터 통합 성능 전략 — Virtual Scroll + Pagination + Timeout 계층
+# ADR-0048: Record 브라우저 대용량 데이터 통합 성능 전략 — Virtual Scroll + Pagination + Timeout 계층
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-05-05-multi-cluster-topology-and-keycloak-oidc.md
+++ b/docs/docs/architecture/adr/2026-05-05-multi-cluster-topology-and-keycloak-oidc.md
@@ -142,7 +142,7 @@ ACKO chart의 `multiCluster.enabled`, `multiCluster.clusters[]` values 키로 �
 - [ADR-0007: Cluster-scoped AerospikeClusterTemplate](./2026-03-12-cluster-scoped-template.md) — 각 operator cluster가 자기 namespace의 Aerospike 클러스터를 관리하는 cluster-scoped 패턴
 - [ADR-0030: Cluster Manager API 인증/인가 아키텍처 및 보안 헤더 강화](./2026-03-30-auth-security-headers.md) — 본 ADR이 채우는 외부 IdP 연동 자리의 출발점
 - [ADR-0038: ACKO 외부 네트워크 접근 — Per-pod LoadBalancer/NodePort 서비스](./2026-04-05-external-network-access.md) — 외부 클라이언트 접근의 네트워크 측면 (본 ADR은 인증 측면)
-- [ADR-0039: ACKO Helm Chart 버전 관리 체계](./2026-04-07-helm-chart-oci-dual-chart.md) — 본 ADR로 추가되는 multiCluster values는 동일 chart 릴리스 체계를 따른다
+- [ADR-0045: ACKO Helm Chart 버전 관리 체계](./2026-04-07-helm-chart-oci-dual-chart.md) — 본 ADR로 추가되는 multiCluster values는 동일 chart 릴리스 체계를 따른다
 
 ## 참고 자료
 

--- a/docs/docs/architecture/adr/2026-05-07-mcp-federation-gateway.md
+++ b/docs/docs/architecture/adr/2026-05-07-mcp-federation-gateway.md
@@ -78,7 +78,7 @@ Phase F1은 bearer pass-through로 시작하고, F2에서 OIDC token exchange를
 
 - gateway는 inbound 요청의 `traceparent` / `tracestate` 헤더를 그대로 backend로 forward한다.
 - gateway 자신은 `mcp.gateway.forward` span을 생성해 incoming agent call ↔ backend ACM span을 연결한다.
-- ADR-0039 (OTel Tracing 통합)에서 정한 W3C trace context 표준을 그대로 따른다. gateway가 OTel SDK를 직접 import하지 않더라도 header pass-through만 보장하면 ADR-0039 trace는 절단되지 않는다.
+- ADR-0046 (OTel Tracing 통합)에서 정한 W3C trace context 표준을 그대로 따른다. gateway가 OTel SDK를 직접 import하지 않더라도 header pass-through만 보장하면 ADR-0046 trace는 절단되지 않는다.
 - Phase 0a (registry decorator Context contract)가 session/workspace 정보를 ctxvar에 stash하는 흐름은 backend 내부에서만 일어나며, gateway는 그에 영향을 주지 않는다. 단, gateway는 `Mcp-Session-Id` 와 `Authorization` 외의 application header를 임의로 strip하지 않는다.
 
 ### 6. mTLS: production 필수, cert-manager 발급 인증서
@@ -196,7 +196,7 @@ F1은 single-tenant에 가까운 운영(internal lab, demo)에 충분하다. F2�
 ## 관련 ADR
 
 - [ADR-0040: Multi-Cluster Topology and Keycloak OIDC for ACKO + Cluster-Manager](./2026-05-05-multi-cluster-topology-and-keycloak-oidc.md) — federation gateway는 ADR-0040의 multi-cluster topology를 LLM 에이전트 surface로 확장한다. Keycloak realm/audience 모델을 그대로 재사용한다.
-- [ADR-0039: OpenTelemetry Tracing 완전 통합 및 에코시스템 전파](./2026-04-07-otel-tracing-integration.md) — gateway는 ADR-0039의 W3C trace context 전파 규칙을 깨지 않는 단순 forward 정책을 따른다.
+- [ADR-0046: OpenTelemetry Tracing 완전 통합 및 에코시스템 전파](./2026-04-07-otel-tracing-integration.md) — gateway는 ADR-0046의 W3C trace context 전파 규칙을 깨지 않는 단순 forward 정책을 따른다.
 - [ADR-0030: Cluster Manager API 인증/인가 아키텍처 및 보안 헤더 강화](./2026-03-30-auth-security-headers.md) — gateway가 backend로 forward하는 토큰의 inbound 검증 모델은 ADR-0030의 native JWT verify 방식 그대로다.
 - [ADR-0008: IssueOps 기반 CI 워크플로우](./2026-03-10-issueops-ci-workflow.md) — gateway 자체 repo / 디렉터리에서도 동일한 IssueOps automation을 따른다.
 

--- a/docs/docs/architecture/adr/2026-05-21-acko-observability-otel-export.md
+++ b/docs/docs/architecture/adr/2026-05-21-acko-observability-otel-export.md
@@ -48,7 +48,7 @@ ADR-0010과 ADR-0046으로 `aerospike-py`는 logging·metrics·tracing 3계층 o
 - **설명**: operator는 기존대로 `/metrics`만 노출하고 tracing을 추가하지 않는다.
 - **장점**: 변경 없음, 의존성 추가 없음.
 - **단점**: reconcile 동작을 trace로 관찰할 수 없고, UI→API→operator end-to-end trace가 단절된다.
-- **미선택 사유**: ADR-0010/0039가 세운 관찰성 목표와 정면으로 배치된다.
+- **미선택 사유**: ADR-0010/0046이 세운 관찰성 목표와 정면으로 배치된다.
 
 ### 대안 2: Helm chart가 OTel Collector를 함께 배포
 

--- a/docs/docs/architecture/adr/2026-05-21-acko-observability-otel-export.md
+++ b/docs/docs/architecture/adr/2026-05-21-acko-observability-otel-export.md
@@ -16,11 +16,11 @@ last_updated: 2026-05-21
 
 - 제안일: 2026-05-21
 - 승인일: 2026-05-21
-- 관련 ADR: [ADR-0010](./2026-02-05-observability-stack.md) (3-Layer Observability Stack), [ADR-0039](./2026-04-07-otel-tracing-integration.md) (OpenTelemetry Tracing 통합)
+- 관련 ADR: [ADR-0010](./2026-02-05-observability-stack.md) (3-Layer Observability Stack), [ADR-0046](./2026-04-07-otel-tracing-integration.md) (OpenTelemetry Tracing 통합)
 
 ## 맥락 (Context)
 
-ADR-0010과 ADR-0039로 `aerospike-py`는 logging·metrics·tracing 3계층 observability를 갖췄고, OpenTelemetry trace context가 PyO3 경계를 넘어 전파된다. 그러나 그 위 계층은 단절돼 있었다.
+ADR-0010과 ADR-0046으로 `aerospike-py`는 logging·metrics·tracing 3계층 observability를 갖췄고, OpenTelemetry trace context가 PyO3 경계를 넘어 전파된다. 그러나 그 위 계층은 단절돼 있었다.
 
 - **ACKO operator (Go)** — Prometheus `/metrics`(controller-runtime + `acko_*`)만 노출했고 tracing이나 OTLP export는 전혀 없었다. reconcile 루프의 동작은 trace로 관찰할 수 없었다.
 - **Cluster Manager API (FastAPI)** — OpenTelemetry SDK는 구성돼 있었지만 `aerospike_py.init_tracing()`을 호출하지 않았다. `[otel]` extra는 context 전파만 연결할 뿐 span *emission*은 시작하지 않으므로, aerospike-py의 `aerospike.<op>` span은 문서의 설명과 달리 실제로는 전량 누락됐다.
@@ -96,7 +96,7 @@ ADR-0010과 ADR-0039로 `aerospike-py`는 logging·metrics·tracing 3계층 obse
 ## 참고 자료
 
 - [ADR-0010: 3-Layer Observability Stack](./2026-02-05-observability-stack.md)
-- [ADR-0039: OpenTelemetry Tracing 완전 통합 및 에코시스템 전파](./2026-04-07-otel-tracing-integration.md)
+- [ADR-0046: OpenTelemetry Tracing 완전 통합 및 에코시스템 전파](./2026-04-07-otel-tracing-integration.md)
 - `acko` PR #279 — operator OpenTelemetry export (traces/metrics/logs)
 - `acko` PR #281 — Helm OTel 활성화 + NetworkPolicy egress
 - `cluster-manager` PR #378 — aerospike-py traces/logs 수집


### PR DESCRIPTION
## Problem

Ten ADR files dated `2026-04-07` were each committed with the **same `ADR-0039` identifier and `sidebar_position: 39`** in their frontmatter. They are ten distinct architecture decisions (git history shows ten separate "add ADR-0039" commits). Consequences:

- The duplicate `sidebar_position: 39` collides in the Docusaurus sidebar.
- The duplicate `ADR-0039` id is factually wrong — only one decision can hold a number.
- `docs/docs/architecture/adr-index.mdx` was stale: its "전체" table stopped at ADR-0015 + ADR-0038, omitting ADR-0016 through ADR-0042.

## Renumbering scheme

The ten files are renumbered **by their git commit timestamp (earliest first)** so the numbering reflects creation order. They sit chronologically between ADR-0038 (2026-04-05) and ADR-0040 (2026-05-05). To avoid colliding with already-correct ADRs, the only free slot in that range is `39`; the remaining nine take the next free numbers `43-51`. ADR-0040/0041/0042 (the May ADRs) are intentionally **not** shifted — renumbering them would expand scope and break their own already-correct ids.

| Commit time | File | Old | New |
|-------------|------|-----|-----|
| 22:19:15 | `2026-04-07-skill-impact-review-pipeline.md` | ADR-0039 | **ADR-0039** (unchanged) |
| 22:19:19 | `2026-04-07-ci-workflow-suite-standardization.md` | ADR-0039 | **ADR-0043** |
| 22:20:07 | `2026-04-07-acko-e2e-expansion-strategy.md` | ADR-0039 | **ADR-0044** |
| 22:20:15 | `2026-04-07-helm-chart-oci-dual-chart.md` | ADR-0039 | **ADR-0045** |
| 22:20:22 | `2026-04-07-otel-tracing-integration.md` | ADR-0039 | **ADR-0046** |
| 22:21:06 | `2026-04-07-numpy-batch-memory-model.md` | ADR-0039 | **ADR-0047** |
| 22:21:18 | `2026-04-07-record-browser-perf-strategy.md` | ADR-0039 | **ADR-0048** |
| 22:22:07 | `2026-04-07-adr-lifecycle-automation.md` | ADR-0039 | **ADR-0049** |
| 22:22:48 | `2026-04-07-dependency-chain-merge-order.md` | ADR-0039 | **ADR-0050** |
| 22:29:07 | `2026-04-07-daily-release-pipeline.md` | ADR-0039 | **ADR-0051** |

For each file: the `ADR-XXXX` in the frontmatter `title`, the in-body H1 heading, and `sidebar_position` were all updated. Filenames do not contain the number, so no `git mv` was needed.

## Cross-references fixed

Three later ADRs linked to the renumbered files and called them ADR-0039:

- `2026-05-05-multi-cluster-topology-and-keycloak-oidc.md` — link to helm-chart ADR → **ADR-0045**
- `2026-05-07-mcp-federation-gateway.md` — references to otel-tracing ADR (2 spots) → **ADR-0046**
- `2026-05-21-acko-observability-otel-export.md` — references to otel-tracing ADR (3 spots) → **ADR-0046**

## adr-index.mdx update

The index was rebuilt so the "전체" tab and all three per-repo tabs (aerospike-py, ACKO, Cluster Manager) list **every ADR (0001-0051)** with correct id, title, date, status, and link — no gaps, no stale stop point. Previously the table jumped from ADR-0015 straight to ADR-0038.

## Note on ADR ids 0017-0036

The `2026-03-30` batch (sidebar_position 17-36) has a **separate, pre-existing** numbering bug: their in-file `title`/H1 prefixes repeat `ADR-0017`/`0018`/`0019`/`0020` even though each file has a unique `sidebar_position`. Fixing those 20 files is out of scope for this PR (which is scoped to the ADR-0039 collision). The index uses each file's unique `sidebar_position` as its canonical id so the index itself is correct and gap-free.

## Verification

`cd docs && npm ci && npm run build` — **succeeds with zero broken-link errors**. Docusaurus fails the build on broken links by default, so this confirms all 51 ADR links resolve. No version bump.