### PR TITLE
docs: refresh last_updated on files corrected in #89

### DIFF
--- a/docs/docs/architecture/deployment-topology.mdx
+++ b/docs/docs/architecture/deployment-topology.mdx
@@ -5,7 +5,7 @@ sidebar_position: 3
 scope: ecosystem
 repos: [acko, cluster-manager]
 tags: [deployment, topology, podman, kubernetes, ce-constraints]
-last_updated: 2026-03-29
+last_updated: 2026-05-23
 ---
 
 import FlowDiagram from '@site/src/components/diagrams/FlowDiagram';

--- a/docs/docs/goals/project-goals.md
+++ b/docs/docs/goals/project-goals.md
@@ -13,7 +13,7 @@ tags:
   - constraints
   - principles
   - development-guidelines
-last_updated: 2026-03-29
+last_updated: 2026-05-23
 ---
 
 # Project Goals

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -14,7 +14,7 @@ tags:
   - introduction
   - ecosystem
   - overview
-last_updated: 2026-03-29
+last_updated: 2026-05-23
 ---
 
 # Aerospike CE Ecosystem Hub

--- a/docs/docs/roadmap/current.md
+++ b/docs/docs/roadmap/current.md
@@ -13,7 +13,7 @@ tags:
   - q2-2026
   - goals
   - planning
-last_updated: 2026-03-29
+last_updated: 2026-05-23
 ---
 
 # 2026-Q2 목표


### PR DESCRIPTION
## Summary

Pure metadata refresh — PR #89 corrected stale facts in four docs but did not bump the `last_updated` frontmatter on any of them. This PR brings the metadata in line with the actual state of the docs.

## Files changed

| File | Change |
|------|--------|
| `docs/docs/intro.md` | `last_updated: 2026-03-29` → `2026-05-23` |
| `docs/docs/architecture/deployment-topology.mdx` | `last_updated: 2026-03-29` → `2026-05-23` |
| `docs/docs/goals/project-goals.md` | `last_updated: 2026-03-29` → `2026-05-23` |
| `docs/docs/roadmap/current.md` | `last_updated: 2026-03-29` → `2026-05-23` |

4 files changed, 4 insertions(+), 4 deletions(-).

## Why this is the only scope

The original task brief also asked to (a) complete the "전체" tab in `adr-index.mdx`, (b) fix `acko-cluster-debugger` references in `project-goals.md` and `roadmap/current.md`. On re-verification all three are already done by earlier PRs:

- **`adr-index.mdx` "전체" tab** — already lists ADR-0001 through ADR-0036 and ADR-0038 through ADR-0051 (0037 intentionally absent per #90's numbering reconciliation). No row is missing.
- **`acko-cluster-debugger` in `project-goals.md` / `roadmap/current.md`** — already say `acko-debugging` (corrected by #89). The remaining mentions in `history/changelog/plugins.md` and `roadmap/milestones/Q1.md` are intentional historical records and must not be rewritten.
- **`adr-index.mdx` `last_updated`** — already `2026-05-23` (touched by #90).

## Verification

- `npm install` then `npm run build` — Docusaurus build succeeds with no broken links or missing references.
- `rg "last_updated" docs/docs/` — confirms each of the four files now reads `2026-05-23`.

## Scope discipline

- PATCH-class only — no ADR decisions, sidebar structure, or content semantics changed.
- No Podman notes added (per repo doc convention).