### PR TITLE
docs: refresh ecosystem release and plugin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docs/docs/
 
 ## Latest ADR
 
-- [ADR-0040: Multi-Cluster Topology and Keycloak OIDC for ACKO + Cluster-Manager](docs/docs/architecture/adr/2026-05-05-multi-cluster-topology-and-keycloak-oidc.md)
+- [ADR-0052: aerospike-py batch_read 병목 프로파일링](docs/docs/architecture/adr/2026-05-23-aerospike-py-batch-read-profiling.md)
 
 ## Development
 

--- a/docs/docs/architecture/adr-index.mdx
+++ b/docs/docs/architecture/adr-index.mdx
@@ -120,6 +120,7 @@ Architecture Decision Record(ADR)는 프로젝트의 중요한 아키텍처 결�
 | [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
 | [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
 | [ADR-0051](./adr/2026-04-07-daily-release-pipeline.md) | 에코시스템 일일 자동 릴리스 파이프라인 | 2026-04-07 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
+| [ADR-0052](./adr/2026-05-23-aerospike-py-batch-read-profiling.md) | aerospike-py batch_read 병목 프로파일링 | 2026-05-23 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> |
 
   </TabItem>
   <TabItem value="aerospike-py" label="aerospike-py">
@@ -145,6 +146,7 @@ Architecture Decision Record(ADR)는 프로젝트의 중요한 아키텍처 결�
 | [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Proposed" /> |
 | [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Proposed" /> |
 | [ADR-0051](./adr/2026-04-07-daily-release-pipeline.md) | 에코시스템 일일 자동 릴리스 파이프라인 | 2026-04-07 | <Status status="Accepted" /> |
+| [ADR-0052](./adr/2026-05-23-aerospike-py-batch-read-profiling.md) | batch_read 병목 프로파일링 | 2026-05-23 | <Status status="Accepted" /> |
 
   </TabItem>
   <TabItem value="acko" label="ACKO">

--- a/docs/docs/architecture/overview.mdx
+++ b/docs/docs/architecture/overview.mdx
@@ -75,7 +75,7 @@ Aerospike CE Ecosystem은 **User → Agent → Plugin** 계층 구조와 **Kuber
 |------|------|
 | **User** | 개발자, DevOps 엔지니어 |
 | **Agent** | Claude Code, claude-code-action 등 AI 에이전트 |
-| **Plugin** | 5개 Skill + 1개 Agent로 ACKO 배포, aerospike-py API 가이드 제공 |
+| **Plugin** | 9개 Skill로 ACKO 배포·운영·디버깅, ackoctl, aerospike-py API, 버그 리포팅 가이드 제공 |
 
 ### 2. Kubernetes 배포 경로
 

--- a/docs/docs/coordination/agentic-workflow.mdx
+++ b/docs/docs/coordination/agentic-workflow.mdx
@@ -244,7 +244,7 @@ Core repo main 머지 (path-filtered)
 | aerospike-py | `exception.py`, `exception.pyi`, `lib.rs` | aerospike-py-api |
 | ACKO | `aerospikecluster_types.go`, `aerospikecluster_webhook.go` | acko-deploy, acko-operations, acko-config-reference |
 | ACKO | `types_storage.go`, `types_network.go`, `types_pod.go`, `types_rack.go` | acko-deploy |
-| ACKO | `reconciler_status.go` | acko-operations, acko-cluster-debugger |
+| ACKO | `reconciler_status.go` | acko-operations, acko-debugging |
 | ACKO | `reconciler_restart.go` | acko-operations |
 
 ### Hub Dispatcher 상세

--- a/docs/docs/goals/project-design.md
+++ b/docs/docs/goals/project-design.md
@@ -73,7 +73,8 @@ Kubernetes의 선언적 패턴을 적극 활용합니다:
 
 에코시스템 전체에 AI 개발 도구를 통합합니다:
 
-- **Claude Code plugins**: 5개 Skills + 1개 Agent로 개발 생산성 향상
+- **Claude Code plugins**: 9개 Skill로 ACKO 배포·운영·디버깅, ackoctl,
+  aerospike-py API, 버그 리포팅 가이드를 제공
 - **Agentic CI**: claude-code-action으로 PR 자동 리뷰 및 피드백
 - **Agentic workflows**: AI가 코드 생성, 리뷰, 테스트, 문서화를 지원
 

--- a/docs/docs/history/releases/release-matrix.md
+++ b/docs/docs/history/releases/release-matrix.md
@@ -7,18 +7,33 @@ repos:
   - aerospike-py
   - acko
   - cluster-manager
+  - ackoctl
   - plugins
 tags:
   - releases
   - compatibility
   - matrix
   - versioning
-last_updated: 2026-05-15
+last_updated: 2026-05-24
 ---
 
 # Release Compatibility Matrix
 
 Aerospike CE Ecosystem 각 프로젝트 간 릴리스 호환성 매트릭스입니다. 동일 행에 있는 버전들은 함께 테스트되었으며 호환성이 검증되었습니다.
+
+---
+
+## Current Latest Tags
+
+2026-05-24 기준 각 core repo의 최신 태그입니다. 이 표는 release freshness 추적용이며, 호환성 보장은 아래 Cross-Project Compatibility Matrix의 행 단위 기준을 따릅니다.
+
+| Project | Latest tag | Tag date | Notes |
+|:---|:---:|:---:|:---|
+| aerospike-py | v0.10.11 | 2026-05-23 | list/map `BY_VALUE` op validation fix |
+| ACKO | v1.7.3 | 2026-05-23 | PodSpec container name + ACL role validation |
+| Cluster Manager | v0.29.2 | 2026-05-23 | bin-name validation coverage fixes |
+| ackoctl | v0.2.0 | 2026-05-15 | release notes for the v0.2.x CLI line |
+| Plugins | v1.5.1 | 2026-05-23 | ackoctl verb/flag and skill metadata fixes |
 
 ---
 
@@ -40,6 +55,7 @@ Aerospike CE Ecosystem 각 프로젝트 간 릴리스 호환성 매트릭스입�
 | v0.1.0~v0.1.5 | 2026-04-02~05 | Stable | Lifecycle state machine, Full Jitter backoff, incremental stabilization |
 | v0.2.0 | 2026-04-07 | Stable | batch_write() API, aerospike crate v2.0.0, in_doubt field exposure |
 | v0.2.1 | 2026-04-07 | Stable | batch_write post-merge review fixes |
+| v0.10.0~v0.10.11 | 2026-05-23 | Stable | LazyBatchRecords/to_numpy performance line, list/map `BY_VALUE` validation hardening |
 
 ---
 
@@ -68,6 +84,7 @@ Aerospike CE Ecosystem 각 프로젝트 간 릴리스 호환성 매트릭스입�
 | v0.3.0~v0.3.2 | 2026-04-02~03 | Webhook network port validation, pod readiness watch, hard-rack template fixes |
 | v0.4.0 | 2026-04-03 | Helm improvements (aerospikeImages, UI K8S_VERIFY_SSL, PostgreSQL PVC) |
 | v0.4.1 | 2026-04-05 | External access support (per-pod LB/NodePort), external endpoints in status |
+| v1.7.0~v1.7.3 | 2026-05-23 | OTel export line stabilization, webhook validation for PodSpec container names and ACL roles |
 
 ---
 
@@ -82,10 +99,20 @@ Aerospike CE Ecosystem 각 프로젝트 간 릴리스 호환성 매트릭스입�
 | v0.4.0 | 2026-03-18 | Feature updates aligned with ACKO v0.1.4+ |
 | v0.5.0~v0.5.2 | 2026-04-02~03 | SSE real-time streaming, parallel health checks, per-connection locks |
 | v0.6.0~v0.6.1 | 2026-04-03 | K8s server-side pagination, security headers, virtual scrolling |
+| v0.29.0~v0.29.2 | 2026-05-23 | K8s and bin-name validation coverage fixes |
 
 :::note
 Cluster Manager follows continuous deployment aligned with ACKO integration milestones. Version tagging started at v0.2.0.
 :::
+
+---
+
+## ackoctl Releases
+
+| Version | Date (approx) | Key Changes |
+|:---:|:---:|:---|
+| v0.1.0~v0.1.4 | 2026-05-13~14 | Initial CLI line for Cluster Manager contexts and resource commands |
+| v0.2.0 | 2026-05-15 | v0.2.x release notes and command surface stabilization |
 
 ---
 
@@ -94,6 +121,7 @@ Cluster Manager follows continuous deployment aligned with ACKO integration mile
 | Version | Date (approx) | Key Changes |
 |:---:|:---:|:---|
 | v1.0.0 | 2026-03-12 | Initial release: 5 skills, 1 agent, 8 deployment examples, 13 reference docs |
+| v1.5.0~v1.5.1 | 2026-05-23 | 9-skill plugin line, ackoctl command corrections, skill metadata hardening |
 
 ---
 
@@ -101,23 +129,24 @@ Cluster Manager follows continuous deployment aligned with ACKO integration mile
 
 동일 행의 버전 조합은 통합 테스트가 완료된 호환 버전입니다.
 
-| aerospike-py | ACKO | Cluster Manager | Plugins | Aerospike CE | Period | Notes |
-|:---:|:---:|:---:|:---:|:---:|:---:|:---|
-| v0.0.1.dev2 | - | - | - | 8.1 | 2026-02-05 | aerospike-py 단독 개발 시작 |
-| v0.0.1.alpha | - | - | - | 8.1 | 2026-02-10 | CDT, expression filters 추가 |
-| v0.0.1.alpha3 | - | - | - | 8.1 | 2026-02-12 | Async client 도입 |
-| v0.0.1.alpha4 | - | - | - | 8.1 | 2026-02-14 | Observability stack 추가 |
-| v0.0.1.alpha6 | - | - | - | 8.1 | 2026-02-17 | Type system, NumPy 통합 |
-| v0.0.1.beta1 | - | - | - | 8.1 | 2026-02-21 | Performance optimization |
-| v0.0.1.beta2 | - | - | - | 8.1 | 2026-02-27 | Quality hardening, i18n |
-| v0.0.1.beta2 | v0.0.1~v0.0.9 | - | - | 8.1 | 2026-03-03 | ACKO 개발 시작, 초기 통합 |
-| v0.0.2 | v0.1.1~v0.1.3 | v0.2.3~v0.3.0 | v1.0.0 | 8.1 | 2026-03-12 | 4개 프로젝트 첫 통합 릴리스 |
-| v0.0.3 | v0.1.4~v0.1.5 | v0.3.1~v0.3.2 | v1.0.0 | 8.1 | 2026-03-19 | API unification, stability |
-| v0.0.4 | v0.1.6~v0.1.7 | v0.3.7~v0.4.0 | v1.0.0 | 8.1 | 2026-03-26 | Q1 최종 릴리스 |
-| v0.0.5 | v0.1.8 | v0.3.8 | v1.0.0 | 8.1 | 2026-03-30 | Q1→Q2 전환, stability + CI 개선 |
-| v0.1.0~v0.1.5 | v0.2.0~v0.3.2 | v0.5.0~v0.5.2 | v1.0.0 | 8.1 | 2026-04-02 | Q2 첫 통합: lifecycle state machine, two-phase config, SSE streaming |
-| v0.1.5 | v0.4.0 | v0.6.0~v0.6.1 | v1.0.0 | 8.1 | 2026-04-03 | Helm improvements, K8s pagination, security headers |
-| v0.2.0~v0.2.1 | v0.4.1 | v0.6.1 | v1.0.0 | 8.1 | 2026-04-07 | Q2 최신: batch_write API, external access, virtual scrolling |
+| aerospike-py | ACKO | Cluster Manager | ackoctl | Plugins | Aerospike CE | Period | Notes |
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---|
+| v0.0.1.dev2 | - | - | - | - | 8.1 | 2026-02-05 | aerospike-py 단독 개발 시작 |
+| v0.0.1.alpha | - | - | - | - | 8.1 | 2026-02-10 | CDT, expression filters 추가 |
+| v0.0.1.alpha3 | - | - | - | - | 8.1 | 2026-02-12 | Async client 도입 |
+| v0.0.1.alpha4 | - | - | - | - | 8.1 | 2026-02-14 | Observability stack 추가 |
+| v0.0.1.alpha6 | - | - | - | - | 8.1 | 2026-02-17 | Type system, NumPy 통합 |
+| v0.0.1.beta1 | - | - | - | - | 8.1 | 2026-02-21 | Performance optimization |
+| v0.0.1.beta2 | - | - | - | - | 8.1 | 2026-02-27 | Quality hardening, i18n |
+| v0.0.1.beta2 | v0.0.1~v0.0.9 | - | - | - | 8.1 | 2026-03-03 | ACKO 개발 시작, 초기 통합 |
+| v0.0.2 | v0.1.1~v0.1.3 | v0.2.3~v0.3.0 | - | v1.0.0 | 8.1 | 2026-03-12 | 4개 프로젝트 첫 통합 릴리스 |
+| v0.0.3 | v0.1.4~v0.1.5 | v0.3.1~v0.3.2 | - | v1.0.0 | 8.1 | 2026-03-19 | API unification, stability |
+| v0.0.4 | v0.1.6~v0.1.7 | v0.3.7~v0.4.0 | - | v1.0.0 | 8.1 | 2026-03-26 | Q1 최종 릴리스 |
+| v0.0.5 | v0.1.8 | v0.3.8 | - | v1.0.0 | 8.1 | 2026-03-30 | Q1→Q2 전환, stability + CI 개선 |
+| v0.1.0~v0.1.5 | v0.2.0~v0.3.2 | v0.5.0~v0.5.2 | - | v1.0.0 | 8.1 | 2026-04-02 | Q2 첫 통합: lifecycle state machine, two-phase config, SSE streaming |
+| v0.1.5 | v0.4.0 | v0.6.0~v0.6.1 | - | v1.0.0 | 8.1 | 2026-04-03 | Helm improvements, K8s pagination, security headers |
+| v0.2.0~v0.2.1 | v0.4.1 | v0.6.1 | - | v1.0.0 | 8.1 | 2026-04-07 | batch_write API, external access, virtual scrolling |
+| v0.10.11 | v1.7.3 | v0.29.2 | v0.2.0 | v1.5.1 | 8.1 | 2026-05-23 | 최신 추적 릴리스: LazyBatchRecords line, webhook validation fixes, ackoctl integration, 9-skill plugin line |
 
 ---
 
@@ -126,6 +155,7 @@ Cluster Manager follows continuous deployment aligned with ACKO integration mile
 - **aerospike-py**: SemVer + pre-release (`dev`, `alpha`, `beta`, `rc`)
 - **ACKO**: SemVer (v0.0.x = pre-stable, v0.1.x = feature-complete)
 - **cluster-manager**: SemVer (ACKO 통합 기준)
+- **ackoctl**: SemVer (cluster-manager REST API와 함께 진화)
 - **plugins**: SemVer
 - **Aerospike CE**: Aerospike Community Edition 서버 버전
 

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -26,9 +26,16 @@ const repos = [
     github: 'https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager',
   },
   {
+    name: 'ackoctl',
+    description: 'Aerospike Cluster Manager CLI',
+    tech: 'Go / cobra',
+    docs: null,
+    github: 'https://github.com/aerospike-ce-ecosystem/ackoctl',
+  },
+  {
     name: 'Plugins',
     description: 'Claude Code 에코시스템 플러그인',
-    tech: 'Skills / Agents',
+    tech: '9 Skills',
     docs: null,
     github: 'https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins',
   },
@@ -77,7 +84,7 @@ function RepoCard({name, description, tech, docs, github}: (typeof repos)[0]) {
   );
 }
 
-export default function Home(): JSX.Element {
+export default function Home() {
   return (
     <Layout description="Aerospike CE Ecosystem Project Hub">
       <HomepageHeader />


### PR DESCRIPTION
## Summary
- Add ADR-0052 to the ADR index and update the README latest ADR pointer.
- Refresh plugin docs from the retired 5 skills + 1 agent model to the current 9-skill model.
- Update the release matrix with current tags and add ackoctl to the compatibility table.
- Fix the docs homepage typecheck issue and include ackoctl in core repos.

## Testing
- npm run typecheck
- npm run build
- comm -23 <(find docs/docs/architecture/adr -maxdepth 1 -type f -name '2026-*.md' -print | sed 's#.*/##' | sort) <(rg -o '\./adr/[^)]+' docs/docs/architecture/adr-index.mdx | sed 's#^\./adr/##' | sort -u)