### PR TITLE
docs: sync ADR index and repo inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docs/docs/
 
 ## Latest ADR
 
-- [ADR-0040: Multi-Cluster Topology and Keycloak OIDC for ACKO + Cluster-Manager](docs/docs/architecture/adr/2026-05-05-multi-cluster-topology-and-keycloak-oidc.md)
+- [ADR-0052: aerospike-py batch_read 병목 프로파일링](docs/docs/architecture/adr/2026-05-23-aerospike-py-batch-read-profiling.md)
 
 ## Development
 

--- a/docs/docs/architecture/adr-index.mdx
+++ b/docs/docs/architecture/adr-index.mdx
@@ -120,6 +120,7 @@ Architecture Decision Record(ADR)는 프로젝트의 중요한 아키텍처 결�
 | [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
 | [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
 | [ADR-0051](./adr/2026-04-07-daily-release-pipeline.md) | 에코시스템 일일 자동 릴리스 파이프라인 | 2026-04-07 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
+| [ADR-0052](./adr/2026-05-23-aerospike-py-batch-read-profiling.md) | aerospike-py batch_read 병목 프로파일링 | 2026-05-23 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> |
 
   </TabItem>
   <TabItem value="aerospike-py" label="aerospike-py">
@@ -145,6 +146,7 @@ Architecture Decision Record(ADR)는 프로젝트의 중요한 아키텍처 결�
 | [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Proposed" /> |
 | [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Proposed" /> |
 | [ADR-0051](./adr/2026-04-07-daily-release-pipeline.md) | 에코시스템 일일 자동 릴리스 파이프라인 | 2026-04-07 | <Status status="Accepted" /> |
+| [ADR-0052](./adr/2026-05-23-aerospike-py-batch-read-profiling.md) | aerospike-py batch_read 병목 프로파일링 | 2026-05-23 | <Status status="Accepted" /> |
 
   </TabItem>
   <TabItem value="acko" label="ACKO">

--- a/docs/docs/architecture/adr/2026-03-30-asyncclient-connect-leak.md
+++ b/docs/docs/architecture/adr/2026-03-30-asyncclient-connect-leak.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0020: aerospike-py AsyncClient 동시 connect() 호출 시 연결 누수 방지 및 lifecycle 안전성 강화"
+title: "ADR-0029: aerospike-py AsyncClient 동시 connect() 호출 시 연결 누수 방지 및 lifecycle 안전성 강화"
 description: aerospike-py AsyncClient에서 동시 connect() 호출 시 발생하는 연결 누수를 AtomicBool guard와 상태 머신으로 방지하고, close() 후 재연결 시 전체 상태를 초기화하는 아키텍처 결정.
 sidebar_position: 29
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, aerospike-py, async, connection-safety, lifecycle, concurrency]
 last_updated: 2026-03-30
 ---
 
-# ADR-0020: aerospike-py AsyncClient 동시 connect() 호출 시 연결 누수 방지 및 lifecycle 안전성 강화
+# ADR-0029: aerospike-py AsyncClient 동시 connect() 호출 시 연결 누수 방지 및 lifecycle 안전성 강화
 
 ## 상태
 
@@ -45,7 +45,7 @@ future_into_py(py, async move {
 
 ### 문제 3: AEROSPIKE_RUNTIME_WORKERS 상한 미검증
 
-`runtime.rs` (lines 31-37)에서 환경변수 `AEROSPIKE_RUNTIME_WORKERS`의 하한(1)만 검증하고 상한이 없어, 비정상적으로 큰 값 설정 시 Tokio 런타임 생성 실패로 Python import 시 panic이 발생합니다. 이 문제는 ADR-0018(Tokio Worker Autotuning)과 범위가 중복되므로, 해당 ADR에서 함께 처리하는 것을 권장합니다.
+`runtime.rs` (lines 31-37)에서 환경변수 `AEROSPIKE_RUNTIME_WORKERS`의 하한(1)만 검증하고 상한이 없어, 비정상적으로 큰 값 설정 시 Tokio 런타임 생성 실패로 Python import 시 panic이 발생합니다. 이 문제는 ADR-0024(Tokio Worker Autotuning)과 범위가 중복되므로, 해당 ADR에서 함께 처리하는 것을 권장합니다.
 
 ## 결정 (Decision)
 
@@ -59,7 +59,7 @@ future_into_py(py, async move {
 
 3. **Client lifecycle 상태 머신**: `Disconnected → Connecting → Connected → Closing → Disconnected` 전이를 명확히 정의하여, 잘못된 상태 전이를 컴파일 타임 또는 런타임에서 방지합니다.
 
-4. **Worker thread 상한 검증**: ADR-0018(Tokio Worker Autotuning)과 통합하여 처리합니다. 이 ADR에서는 문제 1과 2에 집중합니다.
+4. **Worker thread 상한 검증**: ADR-0024(Tokio Worker Autotuning)과 통합하여 처리합니다. 이 ADR에서는 문제 1과 2에 집중합니다.
 
 ## 대안 (Alternatives Considered)
 
@@ -104,4 +104,4 @@ future_into_py(py, async move {
 
 - **ADR-0001 (CFFI 대신 Rust/PyO3 선택)**: Rust의 메모리 안전성이 이 ADR의 기반. PyO3 아키텍처 내에서 동시성 안전성을 강화하는 자연스러운 확장
 - **ADR-0006 (Semaphore 기반 Backpressure)**: 동시 요청 제어의 선례. limiter 상태가 close/reconnect 시 올바르게 관리되어야 함
-- **ADR-0018 (Tokio Worker Autotuning)**: Worker thread 상한 검증 문제가 중복되므로, 해당 ADR에서 통합 처리 권장
+- **ADR-0024 (Tokio Worker Autotuning)**: Worker thread 상한 검증 문제가 중복되므로, 해당 ADR에서 통합 처리 권장

--- a/docs/docs/architecture/adr/2026-03-30-auth-security-headers.md
+++ b/docs/docs/architecture/adr/2026-03-30-auth-security-headers.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0020: Cluster Manager API 인증/인가 아키텍처 및 보안 헤더 강화"
+title: "ADR-0030: Cluster Manager API 인증/인가 아키텍처 및 보안 헤더 강화"
 description: Cluster Manager API에 JWT 기반 인증/인가(RBAC)를 도입하고 보안 헤더(HSTS, CORS 검증)를 강화하여 프로덕션 배포 가능성을 확보하는 아키텍처 결정.
 sidebar_position: 30
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, security, authentication, authorization, rbac, jwt, cors, hsts]
 last_updated: 2026-03-30
 ---
 
-# ADR-0020: Cluster Manager API 인증/인가 아키텍처 및 보안 헤더 강화
+# ADR-0030: Cluster Manager API 인증/인가 아키텍처 및 보안 헤더 강화
 
 ## 상태
 
@@ -97,5 +97,5 @@ ADR-0014 (PostgreSQL 마이그레이션)에서 이미 프로덕션 환경을 고
 
 - [ADR-0014: SQLite → PostgreSQL Migration](/docs/architecture/adr/2026-02-10-postgresql-migration) — 프로덕션 인프라 기반 마련. 감사 로그 저장소로 PostgreSQL 활용 가능
 - [ADR-0016: SSE 기반 실시간 이벤트 스트리밍](/docs/architecture/adr/2026-03-29-sse-event-streaming) — SSE 엔드포인트에도 인증 적용 필요
-- [ADR-0017: Codegen 타입 동기화](/docs/architecture/adr/2026-03-30-codegen-type-sync) — 인증 관련 API 응답 타입(401, 403)도 codegen 범위에 포함 필요
-- [ADR-0018: Graceful Cancellation](/docs/architecture/adr/2026-03-30-graceful-cancellation) — 인증 미들웨어가 요청 취소 흐름에 영향을 주지 않도록 설계 필요
+- [ADR-0019: Codegen 타입 동기화](/docs/architecture/adr/2026-03-30-codegen-type-sync) — 인증 관련 API 응답 타입(401, 403)도 codegen 범위에 포함 필요
+- [ADR-0021: Graceful Cancellation](/docs/architecture/adr/2026-03-30-graceful-cancellation) — 인증 미들웨어가 요청 취소 흐름에 영향을 주지 않도록 설계 필요

--- a/docs/docs/architecture/adr/2026-03-30-circuit-breaker-adaptive-threshold.md
+++ b/docs/docs/architecture/adr/2026-03-30-circuit-breaker-adaptive-threshold.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0017: ACKO Reconciliation Circuit Breaker 임계값 자동 조정 메커니즘"
+title: "ADR-0018: ACKO Reconciliation Circuit Breaker 임계값 자동 조정 메커니즘"
 description: ACKO의 reconciliation circuit breaker 고정 임계값을 에러 유형별 차등 임계값으로 개선하는 제안에 대한 검토 결과. 운영 데이터 부재로 보류.
 sidebar_position: 18
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, acko, kubernetes, reconciliation, circuit-breaker, adaptive-threshol
 last_updated: 2026-03-30
 ---
 
-# ADR-0017: ACKO Reconciliation Circuit Breaker 임계값 자동 조정 메커니즘
+# ADR-0018: ACKO Reconciliation Circuit Breaker 임계값 자동 조정 메커니즘
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-clientmanager-per-connection-lock.md
+++ b/docs/docs/architecture/adr/2026-03-30-clientmanager-per-connection-lock.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0020: Cluster Manager ClientManager 동시성 결함 분석 및 per-connection lock 도입"
+title: "ADR-0031: Cluster Manager ClientManager 동시성 결함 분석 및 per-connection lock 도입"
 description: ClientManager의 double-checked locking race condition을 per-connection-id AsyncLock으로 해결하고, string 기반 에러 감지를 구조화된 result_code 기반으로 전환하는 아키텍처 결정.
 sidebar_position: 31
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, concurrency, connection-management, error-handling, cluster-manager]
 last_updated: 2026-03-30
 ---
 
-# ADR-0020: Cluster Manager ClientManager 동시성 결함 분석 및 per-connection lock 도입
+# ADR-0031: Cluster Manager ClientManager 동시성 결함 분석 및 per-connection lock 도입
 
 ## 상태
 
@@ -47,11 +47,11 @@ async def get_client(self, conn_id: str) -> AsyncClient:
 
 ### 2. String 기반 에러 감지 취약점
 
-`main.py:169`에서 `if "FailForbidden" in msg` 패턴으로 TTL 관련 에러를 감지합니다. aerospike-py의 메시지 포맷 변경 시 silent failure가 발생할 수 있으며, 이는 ADR-0019에서 지적된 anti-pattern과 동일합니다.
+`main.py:169`에서 `if "FailForbidden" in msg` 패턴으로 TTL 관련 에러를 감지합니다. aerospike-py의 메시지 포맷 변경 시 silent failure가 발생할 수 있으며, 이는 ADR-0027에서 지적된 anti-pattern과 동일합니다.
 
 ## 결정 (Decision)
 
-> **per-connection-id AsyncLock을 도입하여 연결 생성의 race condition을 제거하고, string 기반 에러 감지를 ADR-0019의 result_code 기반으로 점진적으로 전환한다.**
+> **per-connection-id AsyncLock을 도입하여 연결 생성의 race condition을 제거하고, string 기반 에러 감지를 ADR-0027의 result_code 기반으로 점진적으로 전환한다.**
 
 ### per-connection-id AsyncLock 구현
 
@@ -85,7 +85,7 @@ class ClientManager:
 ### String 에러 감지 전환 전략
 
 1. **즉시 조치**: 대소문자 무시 매칭 + fallback logging 강화
-2. **ADR-0019 완료 후**: `exc.result_code == ResultCode.FAIL_FORBIDDEN`으로 최종 전환
+2. **ADR-0027 완료 후**: `exc.result_code == ResultCode.FAIL_FORBIDDEN`으로 최종 전환
 
 ## 대안 (Alternatives Considered)
 
@@ -104,7 +104,7 @@ class ClientManager:
 ### 대안 3: 현행 유지 (string 매칭)
 
 - **장점**: 변경 없음
-- **단점**: ADR-0019에서 명시적으로 anti-pattern으로 지적됨. 메시지 변경 시 silent failure 위험
+- **단점**: ADR-0027에서 명시적으로 anti-pattern으로 지적됨. 메시지 변경 시 silent failure 위험
 - **미선택 사유**: 기존 ADR 방향과 불일치
 
 ## 결과 (Consequences)
@@ -114,17 +114,17 @@ class ClientManager:
 - **Race condition 완전 제거**: 동일 `conn_id`에 대한 연결 생성이 직렬화되어 zombie 연결 방지
 - **동시성 유지**: 서로 다른 `conn_id`에 대한 요청은 독립적으로 병렬 처리
 - **CE connection limit 보호**: 불필요한 중복 연결이 제거되어 Aerospike CE의 유한한 connection limit을 효율적으로 사용 (설계 원칙 2-5)
-- **ADR-0019 연계**: string 기반 에러 감지 전환이 ADR-0019의 구현 로드맵과 자연스럽게 연결
+- **ADR-0027 연계**: string 기반 에러 감지 전환이 ADR-0027의 구현 로드맵과 자연스럽게 연결
 - **테스트 가능성**: 동시 `get_client()` 호출에 대한 단위 테스트로 검증 가능
 
 ### 부정적
 
 - **Lock dict 메모리**: `_conn_locks` dict에 삭제된 connection의 lock 객체가 남을 수 있음 (connection 수가 유한하므로 실질적 영향 미미)
 - **Global lock bottleneck**: per-connection lock 획득 시 `_global_lock`을 거치므로 이론적 bottleneck이나, dict 조회는 O(1)이므로 실질적 영향 없음
-- **ADR-0019 의존성**: string 에러 감지의 최종 전환은 aerospike-py의 `result_code` 시스템 완료에 의존
+- **ADR-0027 의존성**: string 에러 감지의 최종 전환은 aerospike-py의 `result_code` 시스템 완료에 의존
 
 ## 관련 ADR
 
 - [ADR-0006: Semaphore 기반 Backpressure](/docs/architecture/adr/2026-03-05-backpressure-semaphore) — 에코시스템의 구조화된 동시성 제어 패턴 선례
-- [ADR-0018: Graceful Cancellation](/docs/architecture/adr/2026-03-30-graceful-cancellation) — Cluster Manager 리소스 관리의 보완적 결정 (연결 종료 시 정리)
-- [ADR-0019: Structured Result Code](/docs/architecture/adr/2026-03-30-structured-result-code) — string 매칭 → result_code 전환의 기반 결정
+- [ADR-0021: Graceful Cancellation](/docs/architecture/adr/2026-03-30-graceful-cancellation) — Cluster Manager 리소스 관리의 보완적 결정 (연결 종료 시 정리)
+- [ADR-0027: Structured Result Code](/docs/architecture/adr/2026-03-30-structured-result-code) — string 매칭 → result_code 전환의 기반 결정

--- a/docs/docs/architecture/adr/2026-03-30-codegen-type-sync.md
+++ b/docs/docs/architecture/adr/2026-03-30-codegen-type-sync.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0017: Cluster Manager Backend↔Frontend 타입 동기화 자동화 (Codegen)"
+title: "ADR-0019: Cluster Manager Backend↔Frontend 타입 동기화 자동화 (Codegen)"
 description: Cluster Manager에서 FastAPI OpenAPI 스키마를 기반으로 TypeScript 타입을 자동 생성하여 Backend↔Frontend 타입 동기화를 자동화하는 아키텍처 결정.
 sidebar_position: 19
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, codegen, openapi, typescript, cluster-manager, type-safety]
 last_updated: 2026-03-30
 ---
 
-# ADR-0017: Cluster Manager Backend↔Frontend 타입 동기화 자동화 (Codegen)
+# ADR-0019: Cluster Manager Backend↔Frontend 타입 동기화 자동화 (Codegen)
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-dynamic-config-transaction.md
+++ b/docs/docs/architecture/adr/2026-03-30-dynamic-config-transaction.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0020: ACKO Dynamic Config 부분 적용 방지를 위한 트랜잭션 보장 전략"
+title: "ADR-0032: ACKO Dynamic Config 부분 적용 방지를 위한 트랜잭션 보장 전략"
 description: ACKO의 동적 설정 변경 시 부분 적용을 방지하기 위해 Two-Phase Commit 패턴과 ConfigDegraded 상태 전환을 도입하는 전략
 sidebar_position: 32
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, acko, dynamic-config, reconciliation, transaction, stabilization]
 last_updated: 2026-03-30
 ---
 
-# ADR-0020: ACKO Dynamic Config 부분 적용 방지를 위한 트랜잭션 보장 전략
+# ADR-0032: ACKO Dynamic Config 부분 적용 방지를 위한 트랜잭션 보장 전략
 
 ## 상태
 
@@ -114,5 +114,5 @@ ADR-0013에서 도입한 5분 reconciliation timeout 내에서 동적 설정 변
 
 - [ADR-0013: Reconciliation Circuit Breaker](/docs/architecture/adr/2026-03-01-reconciliation-circuit-breaker) — 5분 context timeout과 circuit breaker 패턴. 이번 ADR은 해당 timeout 내에서 발생하는 부분 적용 문제를 보완
 - [ADR-0012: Pod Readiness Gates](/docs/architecture/adr/2026-02-20-pod-readiness-gates) — Pod 상태 관리의 세밀한 제어 방향과 일치
-- [ADR-0018: Pause/Resume Status Condition](/docs/architecture/adr/2026-03-30-pause-resume-status-condition) — Status Condition 정합성 보장 패턴의 선례
+- [ADR-0023: Pause/Resume Status Condition](/docs/architecture/adr/2026-03-30-pause-resume-status-condition) — Status Condition 정합성 보장 패턴의 선례
 - [ADR-0002: Kubebuilder v4](/docs/architecture/adr/2026-01-18-kubebuilder-v4) — ACKO의 기반 프레임워크

--- a/docs/docs/architecture/adr/2026-03-30-frontend-resource-leak-prevention.md
+++ b/docs/docs/architecture/adr/2026-03-30-frontend-resource-leak-prevention.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0020: Cluster Manager Frontend 리소스 누수 방지 및 API 호출 최적화"
+title: "ADR-0033: Cluster Manager Frontend 리소스 누수 방지 및 API 호출 최적화"
 description: Cluster Manager 프론트엔드에서 폴링 메모리 누수, AbortController 미사용, 상태 초기화 누락, 에러 정보 미노출 문제를 해결하는 표준 패턴 도입.
 sidebar_position: 33
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, performance, frontend, cluster-manager, resource-management, optimiz
 last_updated: 2026-03-30
 ---
 
-# ADR-0020: Cluster Manager Frontend 리소스 누수 방지 및 API 호출 최적화
+# ADR-0033: Cluster Manager Frontend 리소스 누수 방지 및 API 호출 최적화
 
 ## 상태
 
@@ -32,7 +32,7 @@ ADR-0016에서 SSE 기반 실시간 이벤트 스트리밍이 제안되어 장�
 
 `use-async-data.ts`에서 `requestIdRef`로 stale 업데이트만 방지하고, 실제 fetch 요청은 완료될 때까지 실행됩니다. 의존성이 빠르게 변경되면 동시에 여러 요청이 in-flight 상태가 되어 네트워크 대역폭과 CPU를 낭비합니다.
 
-ADR-0018에서 백엔드 Graceful Cancellation이 제안되었으나, 프론트엔드에서 AbortController로 취소 시그널을 전파해야 백엔드까지 완전한 cancellation 체인이 구축됩니다.
+ADR-0021에서 백엔드 Graceful Cancellation이 제안되었으나, 프론트엔드에서 AbortController로 취소 시그널을 전파해야 백엔드까지 완전한 cancellation 체인이 구축됩니다.
 
 ### 문제 3: 네임스페이스 전환 시 페이지네이션 상태 미초기화
 
@@ -59,7 +59,7 @@ useEffect(() => {
 
 ### 2. useAsyncData에 AbortController 도입
 
-브라우저 내장 AbortController API를 활용하여 의존성 변경 시 이전 요청을 자동 취소합니다. ADR-0018의 백엔드 Graceful Cancellation과 결합하여 완전한 요청 취소 체인을 구축합니다.
+브라우저 내장 AbortController API를 활용하여 의존성 변경 시 이전 요청을 자동 취소합니다. ADR-0021의 백엔드 Graceful Cancellation과 결합하여 완전한 요청 취소 체인을 구축합니다.
 
 ```typescript
 useEffect(() => {
@@ -111,7 +111,7 @@ interface ConnectionHealth {
 ### 긍정적
 - 프론트엔드 메모리 사용량 감소 (폴링 인터벌 누수 제거)
 - 백엔드 API 호출 30-50% 감소 (AbortController + stale 요청 제거)
-- ADR-0018 (Graceful Cancellation)과 결합하여 프론트엔드→백엔드 완전한 요청 취소 체인 구축
+- ADR-0021 (Graceful Cancellation)과 결합하여 프론트엔드→백엔드 완전한 요청 취소 체인 구축
 - 사용자 경험 향상 (정확한 에러 메시지, 일관된 UI 상태)
 - 대규모 클러스터 관리 시 브라우저 성능 안정성 확보 (프로젝트 목표 2-8 부합)
 - ADR-0016 (SSE) 전환 과도기에서의 폴링 안정성 확보
@@ -124,6 +124,6 @@ interface ConnectionHealth {
 ## 관련 ADR
 
 - [ADR-0016: SSE 기반 실시간 이벤트 스트리밍](/docs/architecture/adr/2026-03-29-sse-event-streaming) — 장기적으로 폴링을 SSE로 대체하지만, 전환 과도기 및 fallback에서 폴링 정리 패턴은 여전히 필요
-- [ADR-0018: Graceful Cancellation](/docs/architecture/adr/2026-03-30-graceful-cancellation) — 백엔드 cancellation과 프론트엔드 AbortController가 결합하여 완전한 요청 취소 체인 구축
-- [ADR-0017: 가상 스크롤 도입](/docs/architecture/adr/2026-03-30-virtual-scroll-record-browser) — 레코드 브라우저 성능 개선과 함께 상태 관리 정합성 향상
+- [ADR-0021: Graceful Cancellation](/docs/architecture/adr/2026-03-30-graceful-cancellation) — 백엔드 cancellation과 프론트엔드 AbortController가 결합하여 완전한 요청 취소 체인 구축
+- [ADR-0020: 가상 스크롤 도입](/docs/architecture/adr/2026-03-30-virtual-scroll-record-browser) — 레코드 브라우저 성능 개선과 함께 상태 관리 정합성 향상
 - [ADR-0005: DaisyUI 제거 및 Tailwind CSS 4 전환](/docs/architecture/adr/2026-02-25-daisyui-removal) — 프론트엔드 기술 스택 기준 확립

--- a/docs/docs/architecture/adr/2026-03-30-graceful-cancellation.md
+++ b/docs/docs/architecture/adr/2026-03-30-graceful-cancellation.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0018: Cluster Manager Backend 비동기 연산의 Graceful Cancellation 전략"
+title: "ADR-0021: Cluster Manager Backend 비동기 연산의 Graceful Cancellation 전략"
 description: Cluster Manager Backend에서 클라이언트 연결 끊김 시 장시간 실행 중인 비동기 연산(scan, query, K8s API)을 Graceful하게 취소하는 전략 도입.
 sidebar_position: 21
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, cluster-manager, fastapi, cancellation, async, resource-management]
 last_updated: 2026-03-30
 ---
 
-# ADR-0018: Cluster Manager Backend 비동기 연산의 Graceful Cancellation 전략
+# ADR-0021: Cluster Manager Backend 비동기 연산의 Graceful Cancellation 전략
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-health-check-parallel.md
+++ b/docs/docs/architecture/adr/2026-03-30-health-check-parallel.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0020: Cluster Manager Health Check 병렬화 및 연결 실패 컨텍스트 전파"
+title: "ADR-0034: Cluster Manager Health Check 병렬화 및 연결 실패 컨텍스트 전파"
 description: Cluster Manager 초기 로딩 시 순차 health check를 병렬화하고, 연결 실패 시 에러 유형을 UI에 표시하여 디버깅 편의성을 개선
 sidebar_position: 34
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, cluster-manager, health-check, performance, ux]
 last_updated: 2026-03-30
 ---
 
-# ADR-0020: Cluster Manager Health Check 병렬화 및 연결 실패 컨텍스트 전파
+# ADR-0034: Cluster Manager Health Check 병렬화 및 연결 실패 컨텍스트 전파
 
 ## 상태
 
@@ -88,7 +88,7 @@ Optional `error` 필드를 추가하여 기존 API 호환성을 유지하면서 
 - **장점**: ADR-0016(SSE 이벤트 스트리밍)과 통합 가능
 - **단점**: SSE는 상태 변경 이벤트에 적합하며, 초기 로딩 시 일괄 health check와는 목적이 다름. SSE 도입 후에도 초기 병렬 health check는 여전히 필요
 
-**추천안 선택 이유**: `Promise.allSettled`는 JavaScript 네이티브 API로 추가 의존성 없이 최소한의 변경으로 최대 효과(10x 성능 개선)를 달성한다. 에러 컨텍스트 추가는 ADR-0019의 구조화된 에러 코드 패턴과 일관된 방향이다.
+**추천안 선택 이유**: `Promise.allSettled`는 JavaScript 네이티브 API로 추가 의존성 없이 최소한의 변경으로 최대 효과(10x 성능 개선)를 달성한다. 에러 컨텍스트 추가는 ADR-0027의 구조화된 에러 코드 패턴과 일관된 방향이다.
 
 ## 결과 (Consequences)
 
@@ -98,7 +98,7 @@ Optional `error` 필드를 추가하여 기존 API 호환성을 유지하면서 
 - **에러 원인 즉시 파악**: DevTools 없이 UI에서 네트워크/인증/타임아웃 등 에러 유형 확인 가능
 - **점진적 UX**: 전체 완료까지 빈 화면 대신 진행률 표시 + 개별 결과 점진적 업데이트
 - **기존 API 호환성 유지**: HealthStatus의 `error` 필드는 optional이므로 기존 코드에 영향 없음
-- **에코시스템 일관성**: ADR-0019(구조화된 에러 코드)의 Frontend 적용 사례로 패턴 확립
+- **에코시스템 일관성**: ADR-0027(구조화된 에러 코드)의 Frontend 적용 사례로 패턴 확립
 
 ### 부정적
 
@@ -109,5 +109,5 @@ Optional `error` 필드를 추가하여 기존 API 호환성을 유지하면서 
 
 - [ADR-0015: asinfo 기반 Health Check](/docs/architecture/adr/2026-03-05-asinfo-health-checks) — ACKO K8s 레벨의 health check 전략. 본 ADR은 Cluster Manager UI 레벨의 health check 최적화로 계층이 다름
 - [ADR-0016: SSE 기반 실시간 이벤트 스트리밍](/docs/architecture/adr/2026-03-29-sse-event-streaming) — 실시간 상태 변경 스트리밍과 상호 보완적. SSE 도입 후에도 초기 health check 병렬화는 별도로 필요
-- [ADR-0019: 구조화된 에러 코드 체계](/docs/architecture/adr/2026-03-30-structured-result-code) — aerospike-py의 구조화된 에러 분류 패턴을 Frontend HealthStatus에도 적용하는 일관된 방향
+- [ADR-0027: 구조화된 에러 코드 체계](/docs/architecture/adr/2026-03-30-structured-result-code) — aerospike-py의 구조화된 에러 분류 패턴을 Frontend HealthStatus에도 적용하는 일관된 방향
 - [ADR-0006: Semaphore 기반 Backpressure](/docs/architecture/adr/2026-03-05-backpressure-semaphore) — 동시성 제어 패턴이 에코시스템에 확립되어 있으며, Promise.allSettled도 같은 맥락의 동시 실행 관리

--- a/docs/docs/architecture/adr/2026-03-30-info-batch-aggregation.md
+++ b/docs/docs/architecture/adr/2026-03-30-info-batch-aggregation.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0019: Cluster Manager Aerospike Info 명령 배치 집계로 클러스터 Overview 응답 시간 단축"
+title: "ADR-0025: Cluster Manager Aerospike Info 명령 배치 집계로 클러스터 Overview 응답 시간 단축"
 description: Cluster Manager에서 개별 Aerospike info 호출을 세미콜론 구분자 기반 배치 호출로 통합하고 TTL 캐시를 도입하여 클러스터 Overview 응답 시간을 75% 단축하는 아키텍처 결정.
 sidebar_position: 25
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, performance, cluster-manager, caching, aerospike-info]
 last_updated: 2026-03-30
 ---
 
-# ADR-0019: Cluster Manager Aerospike Info 명령 배치 집계로 클러스터 Overview 응답 시간 단축
+# ADR-0025: Cluster Manager Aerospike Info 명령 배치 집계로 클러스터 Overview 응답 시간 단축
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-k8s-server-side-pagination.md
+++ b/docs/docs/architecture/adr/2026-03-30-k8s-server-side-pagination.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0018: Cluster Manager K8s API에 Server-Side Pagination 및 Namespace Filtering 도입"
+title: "ADR-0022: Cluster Manager K8s API에 Server-Side Pagination 및 Namespace Filtering 도입"
 description: Cluster Manager의 K8s 클러스터 목록 API에 Kubernetes 네이티브 cursor 기반 pagination과 namespace 필터링을 도입하여 대규모 환경 확장성을 확보하는 아키텍처 결정.
 sidebar_position: 22
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, pagination, k8s, performance, cluster-manager, filtering]
 last_updated: 2026-03-30
 ---
 
-# ADR-0018: Cluster Manager K8s API에 Server-Side Pagination 및 Namespace Filtering 도입
+# ADR-0022: Cluster Manager K8s API에 Server-Side Pagination 및 Namespace Filtering 도입
 
 ## 상태
 
@@ -26,7 +26,7 @@ Cluster Manager는 `/api/k8s/clusters` 엔드포인트를 통해 K8s 클러스�
 
 1. **확장성 한계**: 대규모 환경(100+ AerospikeCluster CR)에서 매 조회마다 전체 목록을 K8s API 서버에서 가져오며, JSON 직렬화 및 네트워크 전송 비용이 선형적으로 증가한다.
 2. **필터링 비효율**: 특정 namespace의 클러스터만 필요한 경우에도 전체 조회가 필수이며, K8s RBAC 제한으로 특정 namespace만 접근 가능한 경우 에러 가능성이 있다.
-3. **프론트엔드 병목 유지**: ADR-0017(가상 스크롤)이 프론트엔드 렌더링을 최적화하지만, 백엔드에서 전체 데이터를 전송하는 네트워크/메모리 병목은 그대로 남아있다.
+3. **프론트엔드 병목 유지**: ADR-0020(가상 스크롤)이 프론트엔드 렌더링을 최적화하지만, 백엔드에서 전체 데이터를 전송하는 네트워크/메모리 병목은 그대로 남아있다.
 
 이 문제는 프로젝트 목표 2-2(Backend read/write timeout·limit 관리), 2-6(ACKO 클러스터 관리 편의성·성능), 2-8(대용량 데이터 성능)과 직결된다.
 
@@ -81,8 +81,8 @@ Option A가 K8s API의 네이티브 메커니즘을 활용하여 복잡도 대�
 - K8s API 서버 부하 감소: 페이지 단위(20개)로 조회하여 대규모 환경에서도 안정적
 - 네트워크 대역폭 절감: 전체 CR 목록 대신 페이지 단위 전송
 - RBAC 호환성 개선: `namespace` 파라미터로 접근 가능한 namespace만 조회하여 권한 에러 방지
-- ADR-0017(가상 스크롤)과 시너지: 프론트엔드(렌더링) + 백엔드(데이터 전송) 양쪽 최적화 완성
-- ADR-0017(Codegen 타입 동기화)과 연계: pagination 응답 타입을 OpenAPI → TypeScript 자동 생성 가능
+- ADR-0020(가상 스크롤)과 시너지: 프론트엔드(렌더링) + 백엔드(데이터 전송) 양쪽 최적화 완성
+- ADR-0019(Codegen 타입 동기화)과 연계: pagination 응답 타입을 OpenAPI → TypeScript 자동 생성 가능
 - 하위 호환성: query parameter 없으면 기존 동작 유지
 
 ### 부정적
@@ -92,6 +92,6 @@ Option A가 K8s API의 네이티브 메커니즘을 활용하여 복잡도 대�
 
 ## 관련 ADR
 
-- [ADR-0017: 가상 스크롤 도입](/docs/architecture/adr/2026-03-30-virtual-scroll-record-browser) — 프론트엔드 렌더링 최적화. 이 ADR은 백엔드 데이터 전송 최적화로 상호 보완
-- [ADR-0017: Codegen 타입 동기화](/docs/architecture/adr/2026-03-30-codegen-type-sync) — pagination 응답 타입 동기화에 활용
+- [ADR-0020: 가상 스크롤 도입](/docs/architecture/adr/2026-03-30-virtual-scroll-record-browser) — 프론트엔드 렌더링 최적화. 이 ADR은 백엔드 데이터 전송 최적화로 상호 보완
+- [ADR-0019: Codegen 타입 동기화](/docs/architecture/adr/2026-03-30-codegen-type-sync) — pagination 응답 타입 동기화에 활용
 - [ADR-0016: SSE 이벤트 스트리밍](/docs/architecture/adr/2026-03-29-sse-event-streaming) — Option C(Watch 캐싱)와의 중복을 피하기 위해 cursor 기반 접근 채택

--- a/docs/docs/architecture/adr/2026-03-30-pause-resume-status-condition.md
+++ b/docs/docs/architecture/adr/2026-03-30-pause-resume-status-condition.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0018: ACKO Pause/Resume 상태 전환 시 Status Condition 정합성 보장"
+title: "ADR-0023: ACKO Pause/Resume 상태 전환 시 Status Condition 정합성 보장"
 description: ACKO operator의 Pause/Resume 상태 전환 시 Status Condition 불일치 문제를 해결하기 위해 원자적 업데이트와 Resume condition 리셋을 도입하는 아키텍처 결정.
 sidebar_position: 23
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, acko, kubernetes, pause, resume, status-condition, reconciliation]
 last_updated: 2026-03-30
 ---
 
-# ADR-0018: ACKO Pause/Resume 상태 전환 시 Status Condition 정합성 보장
+# ADR-0023: ACKO Pause/Resume 상태 전환 시 Status Condition 정합성 보장
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-pod-readiness-watch.md
+++ b/docs/docs/architecture/adr/2026-03-30-pod-readiness-watch.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0020: ACKO Pod Readiness Watch 전환 및 Status Enrichment 병렬화"
+title: "ADR-0035: ACKO Pod Readiness Watch 전환 및 Status Enrichment 병렬화"
 description: ACKO의 Pod readiness 확인을 10초 간격 polling에서 Kubernetes Informer watch로 전환하고, status enrichment의 Aerospike 노드 정보 수집을 병렬화하여 reconciliation 성능을 개선하는 아키텍처 결정.
 sidebar_position: 35
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, acko, kubernetes, performance, watch, informer, parallelization, rec
 last_updated: 2026-03-30
 ---
 
-# ADR-0020: ACKO Pod Readiness Watch 전환 및 Status Enrichment 병렬화
+# ADR-0035: ACKO Pod Readiness Watch 전환 및 Status Enrichment 병렬화
 
 ## 상태
 
@@ -133,4 +133,4 @@ CE 제약(최대 8노드)으로 goroutine 수가 자연스럽게 제한된다. C
 - [ADR-0012: Pod Readiness Gates 도입](./2026-02-20-pod-readiness-gates.md) — 커스텀 readiness gate와 결합하여 즉시 감지 효과 극대화
 - [ADR-0013: Reconciliation Circuit Breaker 도입](./2026-03-01-reconciliation-circuit-breaker.md) — reconciliation 안정성 패턴과 공존
 - [ADR-0015: asinfo 기반 Health Check 도입](./2026-03-05-asinfo-health-checks.md) — health check와 pod readiness watch의 역할 분리
-- [ADR-0019: Info 배치 집계](./2026-03-30-info-batch-aggregation.md) — 유사한 성능 최적화 패턴 (Cluster Manager)
+- [ADR-0025: Info 배치 집계](./2026-03-30-info-batch-aggregation.md) — 유사한 성능 최적화 패턴 (Cluster Manager)

--- a/docs/docs/architecture/adr/2026-03-30-record-count-accuracy.md
+++ b/docs/docs/architecture/adr/2026-03-30-record-count-accuracy.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0019: Cluster Manager 레코드 카운트 정확도 개선"
+title: "ADR-0026: Cluster Manager 레코드 카운트 정확도 개선"
 description: Cluster Manager에서 set object count 조회 실패 시 0 대신 None을 반환하여 "알 수 없음" 상태를 명시적으로 표현하고, 프론트엔드 pagination 정상 동작을 보장하는 아키텍처 결정.
 sidebar_position: 26
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, cluster-manager, record-browser, pagination, api-schema, bug-fix]
 last_updated: 2026-03-30
 ---
 
-# ADR-0019: Cluster Manager 레코드 카운트 정확도 개선
+# ADR-0026: Cluster Manager 레코드 카운트 정확도 개선
 
 ## 상태
 
@@ -113,7 +113,7 @@ async def get_set_object_count(...) -> int | None:
 - "레코드 없음" 오표시 제거 — 데이터 신뢰도 향상
 - 필터링된 결과에 대한 정확한 추정치 표시
 - Pagination이 불완전한 count에서도 정상 동작
-- ADR-0017(Virtual Scroll)과 결합 시 대용량 레코드 브라우저 안정성 확보
+- ADR-0020(Virtual Scroll)과 결합 시 대용량 레코드 브라우저 안정성 확보
 - 프로젝트 목표 2-8 달성의 기반 마련
 
 ### 부정적
@@ -126,5 +126,5 @@ async def get_set_object_count(...) -> int | None:
 
 - [ADR-0004: Dict 대신 NamedTuple 반환 선택](/docs/architecture/adr/2026-02-10-namedtuple-over-dict) — 명시적 타입 표현 원칙의 선례
 - [ADR-0009: Unified BatchRecords API](/docs/architecture/adr/2026-03-20-unified-batch-records-api) — per-record 성공/실패 상태 명시적 표현 패턴
-- [ADR-0017: Cluster Manager 레코드 브라우저 가상 스크롤 도입](/docs/architecture/adr/2026-03-30-virtual-scroll-record-browser) — 레코드 브라우저 성능 개선의 연장선
-- [ADR-0017: Backend↔Frontend 타입 동기화 자동화](/docs/architecture/adr/2026-03-30-codegen-type-sync) — API 스키마 변경이 codegen으로 자동 반영 가능
+- [ADR-0020: Cluster Manager 레코드 브라우저 가상 스크롤 도입](/docs/architecture/adr/2026-03-30-virtual-scroll-record-browser) — 레코드 브라우저 성능 개선의 연장선
+- [ADR-0019: Backend↔Frontend 타입 동기화 자동화](/docs/architecture/adr/2026-03-30-codegen-type-sync) — API 스키마 변경이 codegen으로 자동 반영 가능

--- a/docs/docs/architecture/adr/2026-03-30-structured-result-code.md
+++ b/docs/docs/architecture/adr/2026-03-30-structured-result-code.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0019: aerospike-py 구조화된 에러 코드(result_code) 체계 도입"
+title: "ADR-0027: aerospike-py 구조화된 에러 코드(result_code) 체계 도입"
 description: aerospike-py의 모든 AerospikeError 하위 예외에 result_code 정수 속성을 추가하여, 문자열 매칭 대신 안정적인 정수 코드 기반 에러 분류를 지원하는 아키텍처 결정.
 sidebar_position: 27
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, error-handling, result-code, aerospike-py, observability]
 last_updated: 2026-03-30
 ---
 
-# ADR-0019: aerospike-py 구조화된 에러 코드(result_code) 체계 도입
+# ADR-0027: aerospike-py 구조화된 에러 코드(result_code) 체계 도입
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-tokio-worker-autotuning.md
+++ b/docs/docs/architecture/adr/2026-03-30-tokio-worker-autotuning.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0018: aerospike-py Tokio Runtime Worker Thread 자동 튜닝 및 성능 프로파일링"
+title: "ADR-0024: aerospike-py Tokio Runtime Worker Thread 자동 튜닝 및 성능 프로파일링"
 description: aerospike-py의 Tokio runtime worker thread 수를 CPU 코어 기반 heuristic으로 자동 결정하고, RuntimeMetrics를 Prometheus 메트릭으로 노출하는 아키텍처 결정.
 sidebar_position: 24
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, tokio, runtime, performance, metrics, aerospike-py, profiling]
 last_updated: 2026-03-30
 ---
 
-# ADR-0018: aerospike-py Tokio Runtime Worker Thread 자동 튜닝 및 성능 프로파일링
+# ADR-0024: aerospike-py Tokio Runtime Worker Thread 자동 튜닝 및 성능 프로파일링
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-validation-error-circuit-breaker.md
+++ b/docs/docs/architecture/adr/2026-03-30-validation-error-circuit-breaker.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0019: ACKO ValidationError 기반 영구/일시적 오류 분류로 Circuit Breaker 불필요 재시도 방지"
+title: "ADR-0028: ACKO ValidationError 기반 영구/일시적 오류 분류로 Circuit Breaker 불필요 재시도 방지"
 description: ACKO의 기존 ValidationError 타입을 활용하여 영구적 오류를 즉시 식별하고 Circuit Breaker를 즉시 활성화함으로써 불필요한 재시도를 방지하는 아키텍처 결정.
 sidebar_position: 28
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, acko, kubernetes, reconciliation, circuit-breaker, validation, error
 last_updated: 2026-03-30
 ---
 
-# ADR-0019: ACKO ValidationError 기반 영구/일시적 오류 분류로 Circuit Breaker 불필요 재시도 방지
+# ADR-0028: ACKO ValidationError 기반 영구/일시적 오류 분류로 Circuit Breaker 불필요 재시도 방지
 
 ## 상태
 
@@ -34,9 +34,9 @@ ADR-0013에서 도입된 Reconciliation Circuit Breaker는 `maxFailedReconciles 
 2. **오퍼레이터 리소스 낭비**: 실패할 reconcile 루프가 API server, Aerospike 클라이언트 커넥션을 불필요하게 소비
 3. **운영자 혼란**: Circuit Breaker 활성화까지 의미 없는 재시도 이벤트가 K8s Event에 누적되어 실제 문제 진단을 방해
 
-### ADR-0017과의 관계
+### ADR-0018과의 관계
 
-ADR-0017은 에러 유형별 차등 임계값(Transient/Infrastructure/Configuration 3단계 분류)을 제안했으나, 에러 분류 기준 미검증과 복잡성으로 보류되었다. 본 제안은 ADR-0017의 전체 에러 분류 체계가 아닌, **이미 코드에 존재하는 `ValidationError` 타입**을 활용한 단순 이진 분류(영구/일시적)로, ADR-0017의 보류 사유에 해당하지 않는 최소 침습적 접근이다.
+ADR-0018은 에러 유형별 차등 임계값(Transient/Infrastructure/Configuration 3단계 분류)을 제안했으나, 에러 분류 기준 미검증과 복잡성으로 보류되었다. 본 제안은 ADR-0018의 전체 에러 분류 체계가 아닌, **이미 코드에 존재하는 `ValidationError` 타입**을 활용한 단순 이진 분류(영구/일시적)로, ADR-0018의 보류 사유에 해당하지 않는 최소 침습적 접근이다.
 
 ## 결정 (Decision)
 
@@ -45,7 +45,7 @@ ADR-0017은 에러 유형별 차등 임계값(Transient/Infrastructure/Configura
 ### 핵심 변경 사항
 
 1. **ValidationError 즉시 Circuit Break**: `reconciler.go`의 실패 카운터 증가 로직에 `errors.IsValidation(err)` 분기를 추가하여, ValidationError인 경우 `failedReconciles`를 `maxFailedReconciles`로 즉시 설정
-2. **Status Condition 기록**: `reason: PermanentError`, `message: <validation 상세>` 형태로 Status Condition에 기록 (ADR-0013의 `CircuitBreakerOpen` 및 ADR-0018의 `Paused` condition과 동일한 패턴)
+2. **Status Condition 기록**: `reason: PermanentError`, `message: <validation 상세>` 형태로 Status Condition에 기록 (ADR-0013의 `CircuitBreakerOpen` 및 ADR-0023의 `Paused` condition과 동일한 패턴)
 3. **K8s Event 기록**: "영구 오류로 자동 재시도 중단됨" 메시지를 K8s Event에 기록하여 운영자에게 즉시 알림
 4. **Webhook Validation 강화**: 가능한 한 많은 ValidationError를 admission 단계에서 사전 차단
 5. **수동 재시도 지원**: `kubectl annotate ... force-reconcile=true` annotation으로 오판 시 수동 재시도 가능
@@ -70,7 +70,7 @@ ADR-0017은 에러 유형별 차등 임계값(Transient/Infrastructure/Configura
 
 - **장점**: 일시적/영구적 오류 각각에 독립 임계값 설정 가능, 세밀한 제어
 - **단점**: 복잡도 증가, 두 breaker 간 상호작용 관리 필요, 테스트 매트릭스 확대
-- **평가**: 현재 ACKO v0.1.x 규모에서 과도한 설계. ADR-0017 보류 사유와 유사한 복잡성 문제
+- **평가**: 현재 ACKO v0.1.x 규모에서 과도한 설계. ADR-0018 보류 사유와 유사한 복잡성 문제
 
 ## 결과 (Consequences)
 
@@ -93,5 +93,5 @@ ADR-0017은 에러 유형별 차등 임계값(Transient/Infrastructure/Configura
 ## 관련 ADR
 
 - **ADR-0013 (Reconciliation Circuit Breaker 도입)**: 본 제안의 기반. 10회 고정 임계값과 `CircuitBreakerOpen` condition 패턴을 확립
-- **ADR-0017 (Circuit Breaker 임계값 자동 조정)**: 보류됨. 전체 에러 분류 체계의 복잡성 문제를 지적. 본 제안은 이진 분류로 복잡성을 회피
-- **ADR-0018 (Pause/Resume Status Condition)**: Status Condition 기반 상태 노출 패턴을 공유. `PermanentError` reason 추가는 동일한 설계 철학
+- **ADR-0018 (Circuit Breaker 임계값 자동 조정)**: 보류됨. 전체 에러 분류 체계의 복잡성 문제를 지적. 본 제안은 이진 분류로 복잡성을 회피
+- **ADR-0023 (Pause/Resume Status Condition)**: Status Condition 기반 상태 노출 패턴을 공유. `PermanentError` reason 추가는 동일한 설계 철학

--- a/docs/docs/architecture/adr/2026-03-30-virtual-scroll-record-browser.md
+++ b/docs/docs/architecture/adr/2026-03-30-virtual-scroll-record-browser.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0017: Cluster Manager 레코드 브라우저 가상 스크롤 도입"
+title: "ADR-0020: Cluster Manager 레코드 브라우저 가상 스크롤 도입"
 description: Cluster Manager 레코드 브라우저에 TanStack Virtual 기반 가상 스크롤을 도입하여 대용량 레코드 렌더링 성능을 개선하는 아키텍처 결정.
 sidebar_position: 20
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, virtual-scroll, performance, frontend, cluster-manager, tanstack]
 last_updated: 2026-03-30
 ---
 
-# ADR-0017: Cluster Manager 레코드 브라우저 가상 스크롤 도입
+# ADR-0020: Cluster Manager 레코드 브라우저 가상 스크롤 도입
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-webhook-validation-enhancement.md
+++ b/docs/docs/architecture/adr/2026-03-30-webhook-validation-enhancement.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0020: ACKO Webhook Validation 강화 — replication-factor, port overlap, batch size 사전 검증"
+title: "ADR-0036: ACKO Webhook Validation 강화 — replication-factor, port overlap, batch size 사전 검증"
 description: ACKO webhook에 replication-factor, 포트 충돌, batch size 검증을 추가하여 런타임 오류를 admission 단계에서 차단하는 아키텍처 결정
 sidebar_position: 36
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, acko, webhook, validation, stabilization]
 last_updated: 2026-03-30
 ---
 
-# ADR-0020: ACKO Webhook Validation 강화 — replication-factor, port overlap, batch size 사전 검증
+# ADR-0036: ACKO Webhook Validation 강화 — replication-factor, port overlap, batch size 사전 검증
 
 ## 상태
 
@@ -34,9 +34,9 @@ ACKO webhook은 현재 Aerospike CE 라이선스 제약(≤8 노드, ≤2 네임
 
 `maxUnavailable: "10%"`이면 1~9노드 클러스터에서 batch size가 0으로 계산될 수 있다. Rolling restart가 영구 대기 상태에 진입하며, ADR-0013 (Reconciliation Circuit Breaker)의 circuit breaker가 최종적으로 발동하기까지 최대 50분의 불필요한 재시도가 발생한다.
 
-### ADR-0019와의 관계
+### ADR-0028와의 관계
 
-ADR-0019 (ValidationError Circuit Breaker)는 "Webhook Validation Enhancement — Prevent as many ValidationErrors as possible at admission stage"를 명시적으로 권장하고 있다. 위 3가지 오류는 모두 런타임에서 `ValidationError`로 분류될 영구 오류이며, admission 단계에서 차단하면 circuit breaker 활성화 자체를 불필요하게 만든다.
+ADR-0028 (ValidationError Circuit Breaker)는 "Webhook Validation Enhancement — Prevent as many ValidationErrors as possible at admission stage"를 명시적으로 권장하고 있다. 위 3가지 오류는 모두 런타임에서 `ValidationError`로 분류될 영구 오류이며, admission 단계에서 차단하면 circuit breaker 활성화 자체를 불필요하게 만든다.
 
 ## 결정 (Decision)
 
@@ -84,7 +84,7 @@ if batchSize < 1 {
 ### Option B: Controller-level 검증만
 
 - **장점**: webhook 없이도 동작
-- **단점**: Pod 생성 후에야 오류 발견, CrashLoopBackOff 발생 후 디버깅 필요, ADR-0019의 circuit breaker에 의존해야 함
+- **단점**: Pod 생성 후에야 오류 발견, CrashLoopBackOff 발생 후 디버깅 필요, ADR-0028의 circuit breaker에 의존해야 함
 
 ### Option C: Defaulting webhook으로 자동 보정
 
@@ -97,7 +97,7 @@ if batchSize < 1 {
 
 - **즉각적 피드백**: `kubectl apply` 시점에 명확한 에러 메시지로 구성 오류 차단
 - **운영 안정성 향상**: CrashLoopBackOff, split-brain, 영구 대기 상태를 원천 방지
-- **ADR-0019 시너지**: admission 단계에서 영구 오류를 차단하여 reconciliation circuit breaker 불필요 활성화 감소
+- **ADR-0028 시너지**: admission 단계에서 영구 오류를 차단하여 reconciliation circuit breaker 불필요 활성화 감소
 - **Goal 3-5 직접 지원**: CE 제약 Webhook 검증 신뢰성 목표에 부합
 - **Goal 3-4 지원**: E2E 테스트 시나리오 확장 (검증 실패 케이스)
 - **낮은 위험**: 기존 유효한 CR에 영향 없음, 추가 검증만 도입
@@ -110,7 +110,7 @@ if batchSize < 1 {
 
 ## 관련 ADR
 
-- **ADR-0019**: ValidationError Circuit Breaker — webhook validation 강화를 명시적으로 권장
+- **ADR-0028**: ValidationError Circuit Breaker — webhook validation 강화를 명시적으로 권장
 - **ADR-0013**: Reconciliation Circuit Breaker — admission 단계 검증으로 불필요한 reconciliation 실패 방지
 - **ADR-0012**: Pod Readiness Gates — 포트 충돌 방지로 readiness gate 정상 동작 보장
 - **ADR-0002**: Kubebuilder v4 — webhook scaffolding 인프라 기반

--- a/docs/docs/architecture/adr/2026-04-07-acko-e2e-expansion-strategy.md
+++ b/docs/docs/architecture/adr/2026-04-07-acko-e2e-expansion-strategy.md
@@ -104,5 +104,5 @@ GitHub Actions matrix로 시나리오별 병렬 실행.
 - [ADR-0012: Pod Readiness Gates 도입](/docs/architecture/adr/2026-02-20-pod-readiness-gates) — rolling update 시나리오 E2E 검증 대상
 - [ADR-0013: Reconciliation Circuit Breaker 도입](/docs/architecture/adr/2026-03-01-reconciliation-circuit-breaker) — scale up/down 시나리오에서 circuit breaker 동작 검증
 - [ADR-0015: asinfo 기반 Health Check 도입](/docs/architecture/adr/2026-03-05-asinfo-health-checks) — health check 기반 readiness 판단 E2E 검증
-- [ADR-0020: Webhook Validation 강화](/docs/architecture/adr/2026-03-30-webhook-validation-enhancement) — CE 제약 검증의 E2E 레벨 회귀 방지
+- [ADR-0036: Webhook Validation 강화](/docs/architecture/adr/2026-03-30-webhook-validation-enhancement) — CE 제약 검증의 E2E 레벨 회귀 방지
 - [ADR-0038: ACKO 외부 네트워크 접근](/docs/architecture/adr/2026-04-05-external-network-access) — Kind에서 LB 시뮬레이션 테스트 필요성

--- a/docs/docs/architecture/adr/2026-04-07-numpy-batch-memory-model.md
+++ b/docs/docs/architecture/adr/2026-04-07-numpy-batch-memory-model.md
@@ -108,4 +108,4 @@ Q2 2026 로드맵에 "NumPy batch 연산 안정화"가 명시되어 있으며, �
 - [ADR-0001: CFFI 대신 Rust/PyO3 선택](/docs/architecture/adr/2026-01-15-pyo3-over-cffi) — 메모리 안전성 우선 원칙의 근거
 - [ADR-0004: Dict 대신 NamedTuple 반환 선택](/docs/architecture/adr/2026-02-10-namedtuple-over-dict) — 타입 안전성과 개발자 경험 우선 패턴
 - [ADR-0009: Unified BatchRecords API](/docs/architecture/adr/2026-03-20-unified-batch-records-api) — batch 연산 통일 반환 타입, per-record result_code 패턴
-- [ADR-0018: Tokio Runtime Worker Thread 자동 튜닝](/docs/architecture/adr/2026-03-30-tokio-worker-autotuning) — aerospike-py 성능 최적화 관련 선례
+- [ADR-0024: Tokio Runtime Worker Thread 자동 튜닝](/docs/architecture/adr/2026-03-30-tokio-worker-autotuning) — aerospike-py 성능 최적화 관련 선례

--- a/docs/docs/architecture/adr/2026-04-07-record-browser-perf-strategy.md
+++ b/docs/docs/architecture/adr/2026-04-07-record-browser-perf-strategy.md
@@ -108,8 +108,8 @@ Layer 1: Aerospike — socket_timeout (operation 레벨 timeout)
 
 ## 관련 ADR
 
-- [ADR-0017: 가상 스크롤 도입](/docs/architecture/adr/2026-03-30-virtual-scroll-record-browser) — 이 ADR의 "탐색 모드"가 ADR-0017의 TanStack Virtual 결정을 통합
-- [ADR-0018: K8s Server-Side Pagination](/docs/architecture/adr/2026-03-30-k8s-server-side-pagination) — cursor 기반 pagination 패턴의 선례. 이 ADR은 동일 패턴을 record browser에 적용
+- [ADR-0020: 가상 스크롤 도입](/docs/architecture/adr/2026-03-30-virtual-scroll-record-browser) — 이 ADR의 "탐색 모드"가 ADR-0017의 TanStack Virtual 결정을 통합
+- [ADR-0022: K8s Server-Side Pagination](/docs/architecture/adr/2026-03-30-k8s-server-side-pagination) — cursor 기반 pagination 패턴의 선례. 이 ADR은 동일 패턴을 record browser에 적용
 - [ADR-0016: SSE 기반 이벤트 스트리밍](/docs/architecture/adr/2026-03-29-sse-event-streaming) — "탐색 모드"의 streaming 데이터 전송에 SSE/StreamingResponse 패턴 활용
-- [ADR-0018: Graceful Cancellation](/docs/architecture/adr/2026-03-30-graceful-cancellation) — 3계층 timeout의 Backend 계층 구현에 `Request.is_disconnected()` 패턴 활용
+- [ADR-0021: Graceful Cancellation](/docs/architecture/adr/2026-03-30-graceful-cancellation) — 3계층 timeout의 Backend 계층 구현에 `Request.is_disconnected()` 패턴 활용
 - [ADR-0006: Semaphore 기반 Backpressure](/docs/architecture/adr/2026-03-05-backpressure-semaphore) — 요청 수 제한(backpressure)과 데이터 흐름 제어(이 ADR)는 상호보완적 리소스 보호 계층

--- a/docs/docs/architecture/adr/2026-04-07-skill-impact-review-pipeline.md
+++ b/docs/docs/architecture/adr/2026-04-07-skill-impact-review-pipeline.md
@@ -104,5 +104,5 @@ core repo에서 plugins repo로 직접 `workflow_dispatch`. 중간 허브 없이
 ## 관련 ADR
 
 - [ADR-0008: IssueOps 기반 CI 워크플로우](./2026-03-10-issueops-ci-workflow.md) — 이 파이프라인의 기반 패턴. Issue → Plan → Implement 흐름을 cross-repo 감지까지 확장
-- [ADR-0017: Cluster Manager Backend↔Frontend 타입 동기화 자동화](./2026-03-30-codegen-type-sync.md) — repo 내부 타입 동기화의 선례. 이 ADR은 repo 간 API↔Skill 동기화를 다루어 보완적
+- [ADR-0019: Cluster Manager Backend↔Frontend 타입 동기화 자동화](./2026-03-30-codegen-type-sync.md) — repo 내부 타입 동기화의 선례. 이 ADR은 repo 간 API↔Skill 동기화를 다루어 보완적
 - [ADR-0038: ACKO 외부 네트워크 접근](./2026-04-05-external-network-access.md) — CRD 변경이 plugins skill에 영향을 주는 사례. 이 파이프라인이 감지해야 할 대표적 시나리오

--- a/docs/docs/goals/project-design.md
+++ b/docs/docs/goals/project-design.md
@@ -73,7 +73,7 @@ Kubernetes의 선언적 패턴을 적극 활용합니다:
 
 에코시스템 전체에 AI 개발 도구를 통합합니다:
 
-- **Claude Code plugins**: 5개 Skills + 1개 Agent로 개발 생산성 향상
+- **Claude Code plugins**: 9개 Skills로 개발 생산성 향상
 - **Agentic CI**: claude-code-action으로 PR 자동 리뷰 및 피드백
 - **Agentic workflows**: AI가 코드 생성, 리뷰, 테스트, 문서화를 지원
 
@@ -257,6 +257,7 @@ aerospike-ce-ecosystem/          # GitHub Organization
   aerospike-py/                  # Python 클라이언트
   aerospike-ce-kubernetes-operator/  # K8s Operator (ACKO)
   aerospike-cluster-manager/     # 관리 UI
+  ackoctl/                       # Cluster Manager CLI
   aerospike-ce-ecosystem-plugins/    # Claude Code 플러그인
 ```
 

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -26,9 +26,16 @@ const repos = [
     github: 'https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager',
   },
   {
+    name: 'ackoctl',
+    description: 'Aerospike Cluster Manager CLI',
+    tech: 'Go / Cobra',
+    docs: null,
+    github: 'https://github.com/aerospike-ce-ecosystem/ackoctl',
+  },
+  {
     name: 'Plugins',
     description: 'Claude Code 에코시스템 플러그인',
-    tech: 'Skills / Agents',
+    tech: 'Skills',
     docs: null,
     github: 'https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins',
   },
@@ -77,7 +84,7 @@ function RepoCard({name, description, tech, docs, github}: (typeof repos)[0]) {
   );
 }
 
-export default function Home(): JSX.Element {
+export default function Home() {
   return (
     <Layout description="Aerospike CE Ecosystem Project Hub">
       <HomepageHeader />


### PR DESCRIPTION
## Summary
- sync ADR titles, headings, cross-reference labels, and the ADR index with current sidebar positions
- add the latest aerospike-py ADR to the index and README latest-ADR pointer
- refresh Project Hub inventory for ackoctl and current plugin skill counts

## Testing
- git diff --check
- ADR title/H1 number consistency check
- ADR markdown link label consistency check
- npm --prefix docs run typecheck
- npm --prefix docs run build