### PR TITLE
feat: add weekly PR activity dashboard to home page

### DIFF
--- a/.github/workflows/weekly-pr-stats.yml
+++ b/.github/workflows/weekly-pr-stats.yml
@@ -1,0 +1,109 @@
+name: weekly-pr-stats
+
+on:
+  # Every Monday at 09:00 KST (= 00:00 UTC)
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+    inputs:
+      open_pr:
+        description: 'PR로 열기 (기본). false면 main에 직접 commit'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: weekly-pr-stats
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Collect PR stats
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/collect-pr-stats.mjs
+
+      - name: Detect changes
+        id: changes
+        run: |
+          if git diff --quiet -- docs/src/data/pr-stats.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No PR stat changes — skipping."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff --stat -- docs/src/data/pr-stats.json
+          fi
+
+      - name: Summary
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          {
+            echo "## Weekly PR Stats"
+            echo ""
+            echo "Updated \`docs/src/data/pr-stats.json\`."
+            echo ""
+            echo "<details><summary>diff</summary>"
+            echo ""
+            echo '```diff'
+            git diff -- docs/src/data/pr-stats.json | head -200
+            echo '```'
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open PR (default)
+        if: |
+          steps.changes.outputs.changed == 'true' &&
+          (github.event_name == 'schedule' || inputs.open_pr != false)
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: bot/weekly-pr-stats
+          base: main
+          delete-branch: true
+          commit-message: 'chore: refresh weekly PR stats'
+          title: 'chore: refresh weekly PR stats'
+          body: |
+            ## Weekly PR Stats Refresh
+
+            This PR was opened automatically by the `weekly-pr-stats` workflow.
+
+            - Source: `node scripts/collect-pr-stats.mjs`
+            - Output: `docs/src/data/pr-stats.json`
+            - Schedule: 매주 월요일 09:00 KST
+
+            데이터를 검토한 뒤 머지하면 메인 페이지의 통계 카드가 갱신됩니다.
+          labels: |
+            automation
+            stats
+          author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          committer: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+
+      - name: Commit to main (manual override)
+        if: |
+          steps.changes.outputs.changed == 'true' &&
+          github.event_name == 'workflow_dispatch' &&
+          inputs.open_pr == false
+        run: |
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add docs/src/data/pr-stats.json
+          git commit -m 'chore: refresh weekly PR stats'
+          git push origin HEAD:main

--- a/.github/workflows/weekly-pr-stats.yml
+++ b/.github/workflows/weekly-pr-stats.yml
@@ -36,8 +36,12 @@ jobs:
           node-version: '20'
 
       - name: Collect PR stats
+        # Prefer ORG_READ_TOKEN (a fine-grained PAT or App installation token
+        # with org:read + repo:read) when available — the default GITHUB_TOKEN
+        # is repo-scoped and may not be able to list org repos under strict
+        # org policies. Falls back to GITHUB_TOKEN for public-only setups.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ORG_READ_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           node scripts/collect-pr-stats.mjs
 

--- a/.github/workflows/weekly-pr-stats.yml
+++ b/.github/workflows/weekly-pr-stats.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 

--- a/.github/workflows/weekly-pr-stats.yml
+++ b/.github/workflows/weekly-pr-stats.yml
@@ -76,7 +76,9 @@ jobs:
         if: |
           steps.changes.outputs.changed == 'true' &&
           (github.event_name == 'schedule' || inputs.open_pr != false)
-        uses: peter-evans/create-pull-request@v7
+        # Pinned to a commit SHA per OpenSSF Scorecard guidance.
+        # SHA = peter-evans/create-pull-request v7 head (2025-12-05).
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: bot/weekly-pr-stats

--- a/.github/workflows/weekly-pr-stats.yml
+++ b/.github/workflows/weekly-pr-stats.yml
@@ -26,12 +26,12 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: '20'
 

--- a/docs/src/components/HomeStats/RepoMatrix.tsx
+++ b/docs/src/components/HomeStats/RepoMatrix.tsx
@@ -72,8 +72,10 @@ export default function RepoMatrix({
           {weeksAxis.map((w, i) => (
             <tr key={w}>
               <td className={styles.weekCell}>
-                <span className={styles.weekMain}>{weeksKorean[i]}</span>
-                <span className={styles.weekSub}>{weeksDateRange[i]}</span>
+                <div className={styles.weekCellInner}>
+                  <span className={styles.weekMain}>{weeksKorean[i]}</span>
+                  <span className={styles.weekSub}>{weeksDateRange[i]}</span>
+                </div>
               </td>
               {repos.map((r) => {
                 const v = repoSeries[r]?.[i] ?? 0;
@@ -99,7 +101,9 @@ export default function RepoMatrix({
         <tfoot>
           <tr>
             <td className={styles.weekCell}>
-              <span className={styles.weekMain}>전체 합계</span>
+              <div className={styles.weekCellInner}>
+                <span className={styles.weekMain}>전체 합계</span>
+              </div>
             </td>
             {repos.map((r) => (
               <td key={r} className={`${styles.numCell} ${styles.totalCell}`}>

--- a/docs/src/components/HomeStats/RepoMatrix.tsx
+++ b/docs/src/components/HomeStats/RepoMatrix.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import {repoColor, repoLabel} from './constants';
+import styles from './styles.module.css';
+
+interface Props {
+  weeksAxis: string[];
+  weeksKorean: string[];
+  weeksDateRange: string[];
+  repos: string[];
+  repoSeries: Record<string, number[]>;
+  totalPerWeek: number[];
+  perRepoTotal: Record<string, number>;
+  totalPrs: number;
+}
+
+/** Map a value to a heatmap intensity (8% to 70% mix) for the given repo. */
+function heatStyle(repo: string, value: number, max: number): React.CSSProperties {
+  if (value === 0 || max === 0) return {};
+  const intensity = value / max;
+  const pct = 8 + intensity * 62;
+  const color = repoColor(repo);
+  return {
+    background: `color-mix(in srgb, ${color} ${pct.toFixed(0)}%, transparent)`,
+    color: intensity > 0.6 ? '#fff' : 'inherit',
+    fontWeight: 600,
+  };
+}
+
+function totalHeatStyle(value: number, max: number): React.CSSProperties {
+  if (value === 0 || max === 0) return {};
+  const intensity = value / max;
+  const pct = 10 + intensity * 60;
+  return {
+    background: `color-mix(in srgb, var(--matrix-total-tint) ${pct.toFixed(0)}%, transparent)`,
+    color: intensity > 0.55 ? '#fff' : 'inherit',
+    fontWeight: 700,
+  };
+}
+
+export default function RepoMatrix({
+  weeksAxis,
+  weeksKorean,
+  weeksDateRange,
+  repos,
+  repoSeries,
+  totalPerWeek,
+  perRepoTotal,
+  totalPrs,
+}: Props): React.JSX.Element {
+  const repoMax: Record<string, number> = {};
+  for (const r of repos) {
+    repoMax[r] = Math.max(...(repoSeries[r] ?? [0]));
+  }
+  const totalMax = Math.max(...totalPerWeek, 1);
+
+  return (
+    <div className={styles.matrixWrap}>
+      <table className={styles.matrix}>
+        <thead>
+          <tr>
+            <th className={styles.weekHeader}>주차</th>
+            {repos.map((r) => (
+              <th key={r} className={styles.repoHeader}>
+                <span className={styles.repoDot} style={{background: repoColor(r)}} />
+                {repoLabel(r)}
+              </th>
+            ))}
+            <th className={styles.totalHeader}>합계</th>
+          </tr>
+        </thead>
+        <tbody>
+          {weeksAxis.map((w, i) => (
+            <tr key={w}>
+              <td className={styles.weekCell}>
+                <span className={styles.weekMain}>{weeksKorean[i]}</span>
+                <span className={styles.weekSub}>{weeksDateRange[i]}</span>
+              </td>
+              {repos.map((r) => {
+                const v = repoSeries[r]?.[i] ?? 0;
+                return (
+                  <td
+                    key={r}
+                    className={`${styles.numCell} ${v === 0 ? styles.zeroCell : styles.heatCell}`}
+                    style={heatStyle(r, v, repoMax[r] ?? 0)}
+                  >
+                    {v === 0 ? '·' : v}
+                  </td>
+                );
+              })}
+              <td
+                className={`${styles.numCell} ${styles.totalCell} ${totalPerWeek[i] === 0 ? styles.zeroCell : ''}`}
+                style={totalHeatStyle(totalPerWeek[i], totalMax)}
+              >
+                {totalPerWeek[i] === 0 ? '·' : totalPerWeek[i]}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr>
+            <td className={styles.weekCell}>
+              <span className={styles.weekMain}>전체 합계</span>
+            </td>
+            {repos.map((r) => (
+              <td key={r} className={`${styles.numCell} ${styles.totalCell}`}>
+                {perRepoTotal[r] ?? 0}
+              </td>
+            ))}
+            <td className={`${styles.numCell} ${styles.totalCell} ${styles.grandTotal}`}>
+              {totalPrs}
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  );
+}

--- a/docs/src/components/HomeStats/WeeklyChart.tsx
+++ b/docs/src/components/HomeStats/WeeklyChart.tsx
@@ -71,23 +71,30 @@ export default function WeeklyChart({
           );
         })}
 
-        {/* Stacked bars */}
+        {/* Stacked bars — pointer events cover mouse + touch + pen in one path */}
         {weeksAxis.map((_, i) => {
           const x = M.left + bandWidth * i + (bandWidth - barWidth) / 2;
           let cumY = M.top + innerH;
           return (
             <g
               key={i}
-              onMouseEnter={() => setHover(i)}
-              onMouseLeave={() => setHover(null)}
+              role="button"
+              tabIndex={0}
+              aria-label={`${weeksKorean[i]}, 합계 ${totalPerWeek[i]}건`}
+              onPointerEnter={() => setHover(i)}
+              onPointerLeave={() => setHover(null)}
+              onPointerDown={() => setHover(i)}
+              onFocus={() => setHover(i)}
+              onBlur={() => setHover(null)}
             >
-              {/* Hover hit area (full column) */}
+              {/* Hit area — fillOpacity 0 keeps the rect interactive in Safari */}
               <rect
                 x={M.left + bandWidth * i}
                 y={M.top}
                 width={bandWidth}
                 height={innerH}
-                fill="transparent"
+                fill="black"
+                fillOpacity={0}
               />
               {repos.map((repo) => {
                 const v = repoSeries[repo]?.[i] ?? 0;

--- a/docs/src/components/HomeStats/WeeklyChart.tsx
+++ b/docs/src/components/HomeStats/WeeklyChart.tsx
@@ -1,0 +1,167 @@
+import React, {useMemo, useState} from 'react';
+import {repoColor, repoLabel} from './constants';
+import styles from './styles.module.css';
+
+interface Props {
+  weeksKorean: string[];
+  weeksDateRange: string[];
+  weeksAxis: string[];
+  repos: string[];
+  repoSeries: Record<string, number[]>;
+  totalPerWeek: number[];
+}
+
+/**
+ * Pure-SVG stacked bar chart. Horizontal axis = weeks, vertical = PR count.
+ * Hover a bar to see per-repo breakdown in the tooltip.
+ */
+export default function WeeklyChart({
+  weeksKorean,
+  weeksDateRange,
+  weeksAxis,
+  repos,
+  repoSeries,
+  totalPerWeek,
+}: Props): React.JSX.Element {
+  const [hover, setHover] = useState<number | null>(null);
+
+  const W = 920;
+  const H = 320;
+  const M = {top: 16, right: 12, bottom: 56, left: 40};
+  const innerW = W - M.left - M.right;
+  const innerH = H - M.top - M.bottom;
+  const n = weeksAxis.length;
+
+  const maxY = useMemo(() => {
+    const m = Math.max(...totalPerWeek, 1);
+    // round up to nearest 20 for clean grid lines
+    return Math.ceil(m / 20) * 20;
+  }, [totalPerWeek]);
+
+  const bandWidth = innerW / n;
+  const barWidth = Math.max(8, bandWidth * 0.7);
+  const yScale = (v: number) => (v / maxY) * innerH;
+  const yTicks = Array.from({length: 5}, (_, i) => Math.round((maxY / 4) * i));
+
+  return (
+    <div className={styles.chartContainer}>
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        preserveAspectRatio="xMidYMid meet"
+        className={styles.chartSvg}
+        role="img"
+        aria-label="주차별 PR 생성 추이"
+      >
+        {/* Y grid + labels */}
+        {yTicks.map((t) => {
+          const y = M.top + innerH - yScale(t);
+          return (
+            <g key={t}>
+              <line
+                x1={M.left}
+                x2={W - M.right}
+                y1={y}
+                y2={y}
+                className={styles.gridLine}
+              />
+              <text x={M.left - 6} y={y + 4} className={styles.axisLabel} textAnchor="end">
+                {t}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Stacked bars */}
+        {weeksAxis.map((_, i) => {
+          const x = M.left + bandWidth * i + (bandWidth - barWidth) / 2;
+          let cumY = M.top + innerH;
+          return (
+            <g
+              key={i}
+              onMouseEnter={() => setHover(i)}
+              onMouseLeave={() => setHover(null)}
+            >
+              {/* Hover hit area (full column) */}
+              <rect
+                x={M.left + bandWidth * i}
+                y={M.top}
+                width={bandWidth}
+                height={innerH}
+                fill="transparent"
+              />
+              {repos.map((repo) => {
+                const v = repoSeries[repo]?.[i] ?? 0;
+                if (v === 0) return null;
+                const h = yScale(v);
+                cumY -= h;
+                return (
+                  <rect
+                    key={repo}
+                    x={x}
+                    y={cumY}
+                    width={barWidth}
+                    height={h}
+                    fill={repoColor(repo)}
+                    rx={2}
+                    className={hover !== null && hover !== i ? styles.barDim : ''}
+                  />
+                );
+              })}
+            </g>
+          );
+        })}
+
+        {/* X labels — show every other tick on small viewports via CSS class */}
+        {weeksKorean.map((label, i) => {
+          const x = M.left + bandWidth * i + bandWidth / 2;
+          return (
+            <g key={i}>
+              <text
+                x={x}
+                y={H - M.bottom + 18}
+                className={styles.axisLabel}
+                textAnchor="middle"
+              >
+                {label}
+              </text>
+              <text
+                x={x}
+                y={H - M.bottom + 32}
+                className={styles.axisLabelSub}
+                textAnchor="middle"
+              >
+                {weeksDateRange[i]}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      {/* Tooltip */}
+      {hover !== null && (
+        <div
+          className={styles.tooltip}
+          style={{left: `${((hover + 0.5) / n) * 100}%`}}
+        >
+          <div className={styles.tooltipTitle}>
+            {weeksKorean[hover]} <span className={styles.tooltipSub}>· {weeksDateRange[hover]}</span>
+          </div>
+          {repos
+            .map((r) => ({repo: r, count: repoSeries[r]?.[hover] ?? 0}))
+            .filter((d) => d.count > 0)
+            .sort((a, b) => b.count - a.count)
+            .map(({repo, count}) => (
+              <div key={repo} className={styles.tooltipRow}>
+                <span className={styles.tooltipDot} style={{background: repoColor(repo)}} />
+                <span className={styles.tooltipLabel}>{repoLabel(repo)}</span>
+                <span className={styles.tooltipValue}>{count}</span>
+              </div>
+            ))}
+          <div className={styles.tooltipFooter}>
+            합계 <strong>{totalPerWeek[hover]}</strong>건
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/src/components/HomeStats/WeeklyChart.tsx
+++ b/docs/src/components/HomeStats/WeeklyChart.tsx
@@ -137,11 +137,13 @@ export default function WeeklyChart({
         })}
       </svg>
 
-      {/* Tooltip */}
+      {/* Tooltip — clamp to [6%, 94%] so it never spills past the chart bounds */}
       {hover !== null && (
         <div
           className={styles.tooltip}
-          style={{left: `${((hover + 0.5) / n) * 100}%`}}
+          style={{
+            left: `${Math.min(94, Math.max(6, ((hover + 0.5) / n) * 100))}%`,
+          }}
         >
           <div className={styles.tooltipTitle}>
             {weeksKorean[hover]} <span className={styles.tooltipSub}>· {weeksDateRange[hover]}</span>

--- a/docs/src/components/HomeStats/constants.ts
+++ b/docs/src/components/HomeStats/constants.ts
@@ -1,0 +1,38 @@
+// Shared palette + repo label mapping for the home stats panel.
+// Tones picked to read well on both light and dark Docusaurus themes.
+
+export const REPO_COLORS: Record<string, string> = {
+  'aerospike-py':                     '#e11d48', // rose-600
+  'aerospike-cluster-manager':        '#2563eb', // blue-600
+  'aerospike-ce-kubernetes-operator': '#059669', // emerald-600
+  'ackoctl':                          '#d97706', // amber-600
+  'project-hub':                      '#7c3aed', // violet-600
+  'aerospike-ce-ecosystem-plugins':   '#0891b2', // cyan-600
+  'workspace':                        '#475569', // slate-600
+  '.github':                          '#a16207', // yellow-700
+  'aerospike-ce-ui-kit':              '#be185d', // pink-700
+  'aerospike-py-performance-report':  '#0e7490', // cyan-700
+  'homebrew-tap':                     '#854d0e', // yellow-800
+};
+
+export const REPO_SHORT: Record<string, string> = {
+  'aerospike-py':                     'aerospike-py',
+  'aerospike-cluster-manager':        'cluster-manager',
+  'aerospike-ce-kubernetes-operator': 'ACKO',
+  'ackoctl':                          'ackoctl',
+  'project-hub':                      'project-hub',
+  'aerospike-ce-ecosystem-plugins':   'plugins',
+  'workspace':                        'workspace',
+  '.github':                          '.github',
+  'aerospike-ce-ui-kit':              'ui-kit',
+  'aerospike-py-performance-report':  'perf-report',
+  'homebrew-tap':                     'homebrew-tap',
+};
+
+export function repoColor(repo: string): string {
+  return REPO_COLORS[repo] ?? '#64748b';
+}
+
+export function repoLabel(repo: string): string {
+  return REPO_SHORT[repo] ?? repo;
+}

--- a/docs/src/components/HomeStats/index.tsx
+++ b/docs/src/components/HomeStats/index.tsx
@@ -15,13 +15,15 @@ function formatDateKr(iso: string | null): string {
 }
 
 function formatGeneratedKr(iso: string): string {
+  // Render in UTC and label it explicitly — formatDateKr also uses UTC, so the
+  // header (집계 ~ / 마지막 업데이트) stays on one consistent timezone.
   const d = new Date(iso);
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  const h = String(d.getHours()).padStart(2, '0');
-  const min = String(d.getMinutes()).padStart(2, '0');
-  return `${y}.${m}.${day} ${h}:${min}`;
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  const h = String(d.getUTCHours()).padStart(2, '0');
+  const min = String(d.getUTCMinutes()).padStart(2, '0');
+  return `${y}.${m}.${day} ${h}:${min} UTC`;
 }
 
 function Sparkline({values, color}: {values: number[]; color: string}): React.JSX.Element {
@@ -64,7 +66,11 @@ function StateBar(): React.JSX.Element {
 
 function TopContributors(): React.JSX.Element {
   const top = data.topContributors;
-  const max = top[0]?.count ?? 1;
+  if (top.length === 0) {
+    return <p className={styles.muted}>아직 기여자 데이터가 없습니다.</p>;
+  }
+  const max = top[0].count || 1;
+  const denom = data.totalPrs || 1;
   return (
     <div className={styles.contribList}>
       {top.map(({name, count}, i) => (
@@ -75,7 +81,7 @@ function TopContributors(): React.JSX.Element {
             <span className={styles.contribBarFill} style={{width: `${(count / max) * 100}%`}} />
           </span>
           <span className={styles.contribCount}>{count}</span>
-          <span className={styles.contribShare}>{((count / data.totalPrs) * 100).toFixed(1)}%</span>
+          <span className={styles.contribShare}>{((count / denom) * 100).toFixed(1)}%</span>
         </div>
       ))}
     </div>

--- a/docs/src/components/HomeStats/index.tsx
+++ b/docs/src/components/HomeStats/index.tsx
@@ -1,0 +1,268 @@
+import React from 'react';
+import statsData from '@site/src/data/pr-stats.json';
+import type {PrStatsData} from './types';
+import {repoColor, repoLabel} from './constants';
+import WeeklyChart from './WeeklyChart';
+import RepoMatrix from './RepoMatrix';
+import styles from './styles.module.css';
+
+const data: PrStatsData = statsData as PrStatsData;
+
+function formatDateKr(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return `${d.getUTCFullYear()}.${String(d.getUTCMonth() + 1).padStart(2, '0')}.${String(d.getUTCDate()).padStart(2, '0')}`;
+}
+
+function formatGeneratedKr(iso: string): string {
+  const d = new Date(iso);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  const h = String(d.getHours()).padStart(2, '0');
+  const min = String(d.getMinutes()).padStart(2, '0');
+  return `${y}.${m}.${day} ${h}:${min}`;
+}
+
+function Sparkline({values, color}: {values: number[]; color: string}): React.JSX.Element {
+  if (values.length === 0) return <svg />;
+  const W = 60;
+  const H = 18;
+  const max = Math.max(...values, 1);
+  const step = W / Math.max(values.length - 1, 1);
+  const pts = values
+    .map((v, i) => `${i * step},${H - (v / max) * (H - 2) - 1}`)
+    .join(' ');
+  return (
+    <svg width={W} height={H} className={styles.sparkline} aria-hidden>
+      <polyline points={pts} fill="none" stroke={color} strokeWidth={1.5} strokeLinejoin="round" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function StateBar(): React.JSX.Element {
+  const merged = data.stateCounts.MERGED ?? 0;
+  const closed = data.stateCounts.CLOSED ?? 0;
+  const open = data.stateCounts.OPEN ?? 0;
+  const total = merged + closed + open || 1;
+  const pct = (n: number) => `${(n / total) * 100}%`;
+  return (
+    <div className={styles.stateCard}>
+      <div className={styles.stateBar}>
+        <div className={styles.stateSegMerged} style={{width: pct(merged)}} title={`Merged ${merged}`} />
+        <div className={styles.stateSegClosed} style={{width: pct(closed)}} title={`Closed ${closed}`} />
+        <div className={styles.stateSegOpen} style={{width: pct(open)}} title={`Open ${open}`} />
+      </div>
+      <div className={styles.stateLegend}>
+        <span><span className={`${styles.stateDot} ${styles.dotMerged}`} />Merged <strong>{merged}</strong></span>
+        <span><span className={`${styles.stateDot} ${styles.dotClosed}`} />Closed <strong>{closed}</strong></span>
+        <span><span className={`${styles.stateDot} ${styles.dotOpen}`} />Open <strong>{open}</strong></span>
+      </div>
+    </div>
+  );
+}
+
+function TopContributors(): React.JSX.Element {
+  const top = data.topContributors;
+  const max = top[0]?.count ?? 1;
+  return (
+    <div className={styles.contribList}>
+      {top.map(({name, count}, i) => (
+        <div key={name} className={styles.contribRow}>
+          <span className={styles.contribRank}>{i + 1}</span>
+          <span className={styles.contribName}>{name}</span>
+          <span className={styles.contribBarTrack}>
+            <span className={styles.contribBarFill} style={{width: `${(count / max) * 100}%`}} />
+          </span>
+          <span className={styles.contribCount}>{count}</span>
+          <span className={styles.contribShare}>{((count / data.totalPrs) * 100).toFixed(1)}%</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RecentPrs(): React.JSX.Element {
+  return (
+    <div className={styles.recentWrap}>
+      <table className={styles.recentTable}>
+        <thead>
+          <tr>
+            <th>PR</th>
+            <th>Repo</th>
+            <th>Title</th>
+            <th>Author</th>
+            <th>Created</th>
+            <th>State</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.recentPrs.map((pr) => (
+            <tr key={`${pr.repo}-${pr.number}`}>
+              <td>
+                <a href={pr.url} target="_blank" rel="noopener noreferrer">
+                  #{pr.number}
+                </a>
+              </td>
+              <td>
+                <span
+                  className={styles.repoChip}
+                  style={{
+                    background: `color-mix(in srgb, ${repoColor(pr.repo)} 14%, transparent)`,
+                    color: repoColor(pr.repo),
+                  }}
+                >
+                  {repoLabel(pr.repo)}
+                </span>
+              </td>
+              <td className={styles.recentTitle}>{pr.title}</td>
+              <td className={styles.muted}>{pr.author}</td>
+              <td className={styles.muted}>{pr.createdAt.slice(0, 10)}</td>
+              <td>
+                <span className={`${styles.pill} ${styles[`pill${pr.state.charAt(0)}${pr.state.slice(1).toLowerCase()}`]}`}>
+                  {pr.state}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function StatsPanel(): React.JSX.Element {
+  const merged = data.stateCounts.MERGED ?? 0;
+  const mergeRate = data.totalPrs ? (merged / data.totalPrs) * 100 : 0;
+  const last4 = data.recent4Weeks;
+
+  return (
+    <section className={styles.statsRoot}>
+      <div className={styles.statsHeader}>
+        <div>
+          <span className={styles.eyebrow}>ORG Activity</span>
+          <h2 className={styles.statsTitle}>주간 PR 활동 지표</h2>
+          <p className={styles.statsSub}>
+            <code>{data.org}</code> · 집계 <strong>{formatDateKr(data.earliest)} ~ {formatDateKr(data.latest)}</strong>
+            <span className={styles.metaDot}>·</span>
+            매주 월요일 09:00 KST 자동 갱신
+            <span className={styles.metaDot}>·</span>
+            마지막 업데이트 {formatGeneratedKr(data.generatedAt)}
+          </p>
+        </div>
+      </div>
+
+      <div className={styles.kpiGrid}>
+        <div className={`${styles.kpi} ${styles.kpiAccent}`}>
+          <div className={styles.kpiLabel}>총 PR</div>
+          <div className={styles.kpiValue}>{data.totalPrs.toLocaleString()}</div>
+          <div className={styles.kpiHint}>{data.repos.length}개 활성 repo</div>
+        </div>
+        <div className={styles.kpi}>
+          <div className={styles.kpiLabel}>평균 / 주</div>
+          <div className={styles.kpiValue}>{data.avgPerWeek.toFixed(1)}</div>
+          <div className={styles.kpiHint}>{data.weeksAxis.length}주 기준</div>
+        </div>
+        <div className={styles.kpi}>
+          <div className={styles.kpiLabel}>피크 주차</div>
+          <div className={styles.kpiValue}>{data.peakWeek?.count ?? 0}</div>
+          <div className={styles.kpiHint}>{data.peakWeek?.korean ?? '—'}</div>
+        </div>
+        <div className={styles.kpi}>
+          <div className={styles.kpiLabel}>최근 4주</div>
+          <div className={styles.kpiValue}>{data.recent4Total}</div>
+          <div className={styles.kpiHint}>
+            {last4.length > 0
+              ? `${data.weeksKorean[data.weeksAxis.indexOf(last4[0])]} ~ ${data.weeksKorean[data.weeksAxis.indexOf(last4[last4.length - 1])]}`
+              : '—'}
+          </div>
+        </div>
+        <div className={styles.kpi}>
+          <div className={styles.kpiLabel}>Merge Rate</div>
+          <div className={styles.kpiValue}>
+            {mergeRate.toFixed(1)}
+            <span className={styles.kpiUnit}>%</span>
+          </div>
+          <div className={styles.kpiHint}>{merged} merged</div>
+        </div>
+      </div>
+
+      <div className={styles.card}>
+        <div className={styles.cardHead}>
+          <h3>주차별 PR 생성 추이</h3>
+          <span className={styles.cardTag}>Repo 누적 · 월·주차 단위</span>
+        </div>
+        <p className={styles.cardDesc}>막대에 마우스를 올리면 repo별 세부 카운트를 확인할 수 있습니다.</p>
+        <WeeklyChart
+          weeksKorean={data.weeksKorean}
+          weeksDateRange={data.weeksDateRange}
+          weeksAxis={data.weeksAxis}
+          repos={data.repos}
+          repoSeries={data.repoSeries}
+          totalPerWeek={data.totalPerWeek}
+        />
+        <div className={styles.legend}>
+          {data.repos.map((r) => (
+            <span key={r} className={styles.legendChip}>
+              <span className={styles.legendDot} style={{background: repoColor(r)}} />
+              {repoLabel(r)}
+              <span className={styles.legendCount}>{data.perRepoTotal[r]}</span>
+              <Sparkline values={data.repoSeries[r]} color={repoColor(r)} />
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.row2}>
+        <div className={styles.card}>
+          <div className={styles.cardHead}>
+            <h3>PR 상태 분포</h3>
+            <span className={styles.cardTag}>{data.totalPrs}건</span>
+          </div>
+          <p className={styles.cardDesc}>Merge rate: <strong>{mergeRate.toFixed(1)}%</strong></p>
+          <StateBar />
+        </div>
+        <div className={styles.card}>
+          <div className={styles.cardHead}>
+            <h3>Top Contributors</h3>
+            <span className={styles.cardTag}>bot 포함</span>
+          </div>
+          <p className={styles.cardDesc}>PR 생성자 기준 상위 15명</p>
+          <TopContributors />
+        </div>
+      </div>
+
+      <div className={styles.card}>
+        <div className={styles.cardHead}>
+          <h3>주차 × Repo 매트릭스</h3>
+          <span className={styles.cardTag}>{data.weeksAxis.length}주 × {data.repos.length}개 repo</span>
+        </div>
+        <p className={styles.cardDesc}>셀 배경 진하기 = 해당 repo 내 상대적 활동량 · <span className={styles.zeroHint}>·</span> 표기는 0건</p>
+        <RepoMatrix
+          weeksAxis={data.weeksAxis}
+          weeksKorean={data.weeksKorean}
+          weeksDateRange={data.weeksDateRange}
+          repos={data.repos}
+          repoSeries={data.repoSeries}
+          totalPerWeek={data.totalPerWeek}
+          perRepoTotal={data.perRepoTotal}
+          totalPrs={data.totalPrs}
+        />
+      </div>
+
+      <div className={styles.card}>
+        <div className={styles.cardHead}>
+          <h3>최근 PR</h3>
+          <span className={styles.cardTag}>생성일 내림차순 · 30건</span>
+        </div>
+        <p className={styles.cardDesc}>PR 번호 클릭 시 GitHub에서 열림</p>
+        <RecentPrs />
+      </div>
+    </section>
+  );
+}
+
+export default function HomeStats(): React.JSX.Element {
+  // SSR-safe: render same markup server-side; charts are pure SVG so hydration is fine
+  return <StatsPanel />;
+}

--- a/docs/src/components/HomeStats/styles.module.css
+++ b/docs/src/components/HomeStats/styles.module.css
@@ -209,7 +209,7 @@
 }
 .tooltip {
   position: absolute;
-  bottom: calc(100% + -32px);
+  top: 12px;
   transform: translateX(-50%);
   background: var(--ifm-color-emphasis-900, #18181b);
   color: var(--ifm-color-emphasis-0, #fff);
@@ -218,6 +218,7 @@
   font-size: 12px;
   pointer-events: none;
   min-width: 200px;
+  max-width: 280px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.16);
   z-index: 5;
 }
@@ -427,10 +428,12 @@
 }
 .weekCell {
   border-right: 1px solid var(--hs-border);
+  min-width: 140px;
+}
+.weekCellInner {
   display: flex;
   align-items: baseline;
   gap: 8px;
-  min-width: 140px;
 }
 .weekMain {
   font-weight: 600;

--- a/docs/src/components/HomeStats/styles.module.css
+++ b/docs/src/components/HomeStats/styles.module.css
@@ -1,0 +1,528 @@
+/* Theme-aware tokens — light/dark aware via Docusaurus [data-theme] */
+.statsRoot {
+  --hs-surface: var(--ifm-card-background-color, #ffffff);
+  --hs-surface-2: var(--ifm-color-emphasis-100);
+  --hs-border: var(--ifm-color-emphasis-200);
+  --hs-border-2: var(--ifm-color-emphasis-100);
+  --hs-text: var(--ifm-color-content);
+  --hs-text-2: var(--ifm-color-content-secondary);
+  --hs-muted: var(--ifm-color-emphasis-500);
+  --hs-accent: #e11d48;
+  --hs-accent-bg: color-mix(in srgb, #e11d48 8%, transparent);
+  --hs-green: #059669;
+  --hs-amber: #d97706;
+  --hs-slate: #64748b;
+  --hs-radius: 12px;
+  --matrix-total-tint: #18181b;
+
+  margin: 3rem 0 1rem;
+}
+
+[data-theme='dark'] .statsRoot {
+  --hs-accent-bg: color-mix(in srgb, #f43f5e 14%, transparent);
+  --matrix-total-tint: #f4f4f5;
+}
+
+/* ─── Header ──────────────────────────────────────────── */
+.statsHeader {
+  margin-bottom: 1.5rem;
+}
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--hs-accent-bg);
+  color: var(--hs-accent);
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.eyebrow::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--hs-accent);
+  animation: hs-pulse 2.4s ease-in-out infinite;
+}
+@keyframes hs-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+.statsTitle {
+  margin: 12px 0 6px;
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+.statsSub {
+  margin: 0;
+  color: var(--hs-text-2);
+  font-size: 13.5px;
+}
+.statsSub code {
+  font-size: 12.5px;
+  padding: 1px 6px;
+  background: var(--hs-surface-2);
+  border-radius: 4px;
+}
+.metaDot {
+  margin: 0 8px;
+  color: var(--hs-muted);
+}
+
+/* ─── KPI ─────────────────────────────────────────────── */
+.kpiGrid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  margin-bottom: 20px;
+}
+.kpi {
+  padding: 18px 20px;
+  border: 1px solid var(--hs-border);
+  border-radius: var(--hs-radius);
+  background: var(--hs-surface);
+}
+.kpiAccent {
+  position: relative;
+  overflow: hidden;
+}
+.kpiAccent::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: var(--hs-accent);
+}
+.kpiAccent .kpiValue {
+  color: var(--hs-accent);
+}
+.kpiLabel {
+  font-size: 12px;
+  color: var(--hs-text-2);
+  font-weight: 500;
+}
+.kpiValue {
+  margin-top: 6px;
+  font-size: 30px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+}
+.kpiUnit {
+  font-size: 18px;
+  color: var(--hs-muted);
+  margin-left: 2px;
+}
+.kpiHint {
+  margin-top: 4px;
+  font-size: 12.5px;
+  color: var(--hs-muted);
+}
+
+/* ─── Cards ───────────────────────────────────────────── */
+.card {
+  padding: 22px 24px;
+  border: 1px solid var(--hs-border);
+  border-radius: var(--hs-radius);
+  background: var(--hs-surface);
+  margin-bottom: 16px;
+}
+.cardHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 4px;
+}
+.cardHead h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.cardDesc {
+  margin: 0 0 16px;
+  color: var(--hs-muted);
+  font-size: 13px;
+}
+.cardTag {
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--hs-text-2);
+  padding: 3px 8px;
+  background: var(--hs-surface-2);
+  border-radius: 6px;
+  font-variant-numeric: tabular-nums;
+}
+.zeroHint {
+  color: var(--hs-muted);
+  font-weight: 700;
+  margin: 0 2px;
+}
+
+.row2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+.row2 > .card { margin-bottom: 16px; }
+@media (max-width: 880px) {
+  .row2 { grid-template-columns: 1fr; }
+}
+
+/* ─── Weekly Chart ────────────────────────────────────── */
+.chartContainer {
+  position: relative;
+  width: 100%;
+}
+.chartSvg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+.gridLine {
+  stroke: var(--hs-border-2);
+  stroke-width: 1;
+  stroke-dasharray: 2 3;
+}
+.axisLabel {
+  fill: var(--hs-text-2);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+.axisLabelSub {
+  fill: var(--hs-muted);
+  font-size: 9.5px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+.barDim {
+  opacity: 0.35;
+  transition: opacity 0.12s ease;
+}
+.tooltip {
+  position: absolute;
+  bottom: calc(100% + -32px);
+  transform: translateX(-50%);
+  background: var(--ifm-color-emphasis-900, #18181b);
+  color: var(--ifm-color-emphasis-0, #fff);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 12px;
+  pointer-events: none;
+  min-width: 200px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.16);
+  z-index: 5;
+}
+.tooltipTitle {
+  font-weight: 600;
+  font-size: 12.5px;
+  margin-bottom: 6px;
+}
+.tooltipSub {
+  color: var(--ifm-color-emphasis-400);
+  font-weight: 400;
+  font-size: 11px;
+}
+.tooltipRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 3px;
+}
+.tooltipDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+}
+.tooltipLabel {
+  flex: 1;
+  color: var(--ifm-color-emphasis-200);
+}
+.tooltipValue {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+.tooltipFooter {
+  margin-top: 8px;
+  padding-top: 6px;
+  border-top: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+  font-size: 11.5px;
+  color: var(--ifm-color-emphasis-300);
+}
+.tooltipFooter strong {
+  color: var(--ifm-color-emphasis-0);
+}
+
+/* ─── Legend ──────────────────────────────────────────── */
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+.legendChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px 4px 8px;
+  border: 1px solid var(--hs-border);
+  border-radius: 999px;
+  font-size: 12px;
+  color: var(--hs-text-2);
+  background: var(--hs-surface);
+}
+.legendDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+}
+.legendCount {
+  font-weight: 600;
+  color: var(--hs-text);
+  font-variant-numeric: tabular-nums;
+}
+.sparkline {
+  display: block;
+}
+
+/* ─── State Distribution ─────────────────────────────── */
+.stateCard { width: 100%; }
+.stateBar {
+  display: flex;
+  width: 100%;
+  height: 36px;
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--hs-surface-2);
+}
+.stateSegMerged { background: var(--hs-green); }
+.stateSegClosed { background: var(--hs-slate); }
+.stateSegOpen { background: var(--hs-amber); }
+.stateLegend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 12px;
+  font-size: 13px;
+  color: var(--hs-text-2);
+}
+.stateLegend strong {
+  color: var(--hs-text);
+  margin-left: 2px;
+  font-variant-numeric: tabular-nums;
+}
+.stateDot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+.dotMerged { background: var(--hs-green); }
+.dotClosed { background: var(--hs-slate); }
+.dotOpen { background: var(--hs-amber); }
+
+/* ─── Top Contributors ──────────────────────────────── */
+.contribList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.contribRow {
+  display: grid;
+  grid-template-columns: 26px 1fr 100px 44px 52px;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 0;
+  font-size: 13.5px;
+}
+.contribRank {
+  text-align: right;
+  color: var(--hs-muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+}
+.contribName {
+  color: var(--hs-text);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.contribBarTrack {
+  position: relative;
+  height: 6px;
+  background: var(--hs-border-2);
+  border-radius: 3px;
+}
+.contribBarFill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--hs-accent);
+  opacity: 0.6;
+  border-radius: 3px;
+}
+.contribCount {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+.contribShare {
+  text-align: right;
+  color: var(--hs-text-2);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+@media (max-width: 540px) {
+  .contribRow {
+    grid-template-columns: 22px 1fr 36px 42px;
+  }
+  .contribBarTrack { display: none; }
+}
+
+/* ─── Repo × Week Matrix ─────────────────────────────── */
+.matrixWrap {
+  overflow-x: auto;
+  margin: 0 -4px;
+}
+.matrix {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.matrix th, .matrix td {
+  padding: 8px 10px;
+  text-align: left;
+  border-bottom: 1px solid var(--hs-border-2);
+  white-space: nowrap;
+}
+.matrix th {
+  color: var(--hs-text-2);
+  font-weight: 500;
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--hs-surface-2);
+  border-bottom: 1px solid var(--hs-border);
+}
+.weekHeader { text-align: left; }
+.repoHeader { text-align: center; }
+.totalHeader { text-align: center; }
+.repoDot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+.weekCell {
+  border-right: 1px solid var(--hs-border);
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 140px;
+}
+.weekMain {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--hs-text);
+}
+.weekSub {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px;
+  color: var(--hs-muted);
+}
+.numCell {
+  width: 60px;
+  min-width: 60px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  border-radius: 4px;
+}
+.heatCell { font-weight: 600; }
+.zeroCell { color: color-mix(in srgb, var(--hs-muted) 60%, transparent); font-weight: 400; }
+.totalCell {
+  font-weight: 700;
+  border-left: 1px solid var(--hs-border);
+  text-align: center;
+}
+.matrix tfoot td {
+  background: var(--hs-surface-2);
+  border-top: 2px solid var(--hs-border);
+  border-bottom: none;
+  font-weight: 700;
+}
+.grandTotal {
+  color: var(--hs-accent);
+}
+
+/* ─── Recent PRs ──────────────────────────────────────── */
+.recentWrap {
+  overflow-x: auto;
+  margin: 0 -4px;
+}
+.recentTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+.recentTable th, .recentTable td {
+  padding: 9px 10px;
+  text-align: left;
+  border-bottom: 1px solid var(--hs-border-2);
+  vertical-align: middle;
+}
+.recentTable th {
+  color: var(--hs-text-2);
+  font-weight: 500;
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--hs-surface-2);
+  border-bottom: 1px solid var(--hs-border);
+}
+.recentTable a {
+  color: var(--hs-accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+.recentTable a:hover { text-decoration: underline; }
+.recentTitle {
+  max-width: 360px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.muted { color: var(--hs-text-2); }
+.repoChip {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 5px;
+  font-size: 11.5px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+/* PR state pill */
+.pill {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 5px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.pillMerged { background: color-mix(in srgb, var(--hs-green) 14%, transparent); color: var(--hs-green); }
+.pillOpen { background: color-mix(in srgb, var(--hs-amber) 14%, transparent); color: var(--hs-amber); }
+.pillClosed { background: color-mix(in srgb, var(--hs-slate) 18%, transparent); color: var(--hs-slate); }

--- a/docs/src/components/HomeStats/types.ts
+++ b/docs/src/components/HomeStats/types.ts
@@ -1,0 +1,30 @@
+export interface PrStatsData {
+  generatedAt: string;
+  org: string;
+  earliest: string | null;
+  latest: string | null;
+  totalPrs: number;
+  repos: string[];
+  perRepoTotal: Record<string, number>;
+  weeksAxis: string[];
+  weeksKorean: string[];
+  weeksDateRange: string[];
+  repoSeries: Record<string, number[]>;
+  totalPerWeek: number[];
+  recent4Weeks: string[];
+  recent4Total: number;
+  peakWeek: {week: string; korean: string; count: number} | null;
+  avgPerWeek: number;
+  stateCounts: Record<string, number>;
+  topContributors: {name: string; count: number}[];
+  monthly: {month: string; count: number}[];
+  recentPrs: {
+    repo: string;
+    number: number;
+    title: string;
+    url: string;
+    author: string;
+    createdAt: string;
+    state: string;
+  }[];
+}

--- a/docs/src/data/pr-stats.json
+++ b/docs/src/data/pr-stats.json
@@ -1,0 +1,583 @@
+{
+  "generatedAt": "2026-05-27T03:02:24.478Z",
+  "org": "aerospike-ce-ecosystem",
+  "earliest": "2026-02-05T15:28:20.000Z",
+  "latest": "2026-05-26T06:33:44.000Z",
+  "totalPrs": 986,
+  "repos": [
+    "aerospike-py",
+    "aerospike-cluster-manager",
+    "aerospike-ce-kubernetes-operator",
+    "ackoctl",
+    "project-hub",
+    "aerospike-ce-ecosystem-plugins",
+    "workspace",
+    ".github"
+  ],
+  "perRepoTotal": {
+    "aerospike-py": 278,
+    "aerospike-cluster-manager": 350,
+    "aerospike-ce-kubernetes-operator": 210,
+    "ackoctl": 48,
+    "project-hub": 45,
+    "aerospike-ce-ecosystem-plugins": 34,
+    "workspace": 17,
+    ".github": 4
+  },
+  "weeksAxis": [
+    "2026-W06",
+    "2026-W07",
+    "2026-W08",
+    "2026-W09",
+    "2026-W10",
+    "2026-W11",
+    "2026-W12",
+    "2026-W13",
+    "2026-W14",
+    "2026-W15",
+    "2026-W16",
+    "2026-W17",
+    "2026-W18",
+    "2026-W19",
+    "2026-W20",
+    "2026-W21",
+    "2026-W22"
+  ],
+  "weeksKorean": [
+    "2월 1주차",
+    "2월 2주차",
+    "2월 3주차",
+    "2월 4주차",
+    "3월 1주차",
+    "3월 2주차",
+    "3월 3주차",
+    "3월 4주차",
+    "3월 5주차",
+    "4월 1주차",
+    "4월 2주차",
+    "4월 3주차",
+    "4월 4주차",
+    "5월 1주차",
+    "5월 2주차",
+    "5월 3주차",
+    "5월 4주차"
+  ],
+  "weeksDateRange": [
+    "2/02–2/08",
+    "2/09–2/15",
+    "2/16–2/22",
+    "2/23–3/01",
+    "3/02–3/08",
+    "3/09–3/15",
+    "3/16–3/22",
+    "3/23–3/29",
+    "3/30–4/05",
+    "4/06–4/12",
+    "4/13–4/19",
+    "4/20–4/26",
+    "4/27–5/03",
+    "5/04–5/10",
+    "5/11–5/17",
+    "5/18–5/24",
+    "5/25–5/31"
+  ],
+  "repoSeries": {
+    "aerospike-py": [
+      40,
+      31,
+      24,
+      26,
+      22,
+      10,
+      8,
+      18,
+      3,
+      18,
+      7,
+      8,
+      22,
+      8,
+      11,
+      18,
+      4
+    ],
+    "aerospike-cluster-manager": [
+      0,
+      11,
+      26,
+      21,
+      24,
+      35,
+      23,
+      13,
+      23,
+      5,
+      8,
+      15,
+      32,
+      61,
+      14,
+      31,
+      8
+    ],
+    "aerospike-ce-kubernetes-operator": [
+      0,
+      0,
+      8,
+      38,
+      46,
+      16,
+      15,
+      6,
+      13,
+      0,
+      1,
+      1,
+      12,
+      19,
+      8,
+      25,
+      2
+    ],
+    "ackoctl": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      28,
+      18,
+      2
+    ],
+    "project-hub": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      1,
+      21,
+      12,
+      0,
+      0,
+      0,
+      2,
+      1,
+      7,
+      1
+    ],
+    "aerospike-ce-ecosystem-plugins": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      1,
+      0,
+      1,
+      0,
+      0,
+      8,
+      8,
+      7,
+      8,
+      1
+    ],
+    "workspace": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      2,
+      1,
+      0,
+      0,
+      0,
+      6,
+      5,
+      3,
+      0
+    ],
+    ".github": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      1,
+      0,
+      2,
+      1,
+      0,
+      0
+    ]
+  },
+  "totalPerWeek": [
+    40,
+    42,
+    58,
+    85,
+    92,
+    61,
+    46,
+    39,
+    62,
+    37,
+    16,
+    25,
+    74,
+    106,
+    75,
+    110,
+    18
+  ],
+  "recent4Weeks": [
+    "2026-W19",
+    "2026-W20",
+    "2026-W21",
+    "2026-W22"
+  ],
+  "recent4Total": 309,
+  "peakWeek": {
+    "week": "2026-W21",
+    "korean": "5월 3주차",
+    "count": 110
+  },
+  "avgPerWeek": 58,
+  "stateCounts": {
+    "MERGED": 885,
+    "OPEN": 20,
+    "CLOSED": 81
+  },
+  "topContributors": [
+    {
+      "name": "KimSoungRyoul",
+      "count": 847
+    },
+    {
+      "name": "app/dependabot",
+      "count": 134
+    },
+    {
+      "name": "app/github-actions",
+      "count": 4
+    },
+    {
+      "name": "app/claude",
+      "count": 1
+    }
+  ],
+  "monthly": [
+    {
+      "month": "2026-02",
+      "count": 201
+    },
+    {
+      "month": "2026-03",
+      "count": 302
+    },
+    {
+      "month": "2026-04",
+      "count": 149
+    },
+    {
+      "month": "2026-05",
+      "count": 334
+    }
+  ],
+  "recentPrs": [
+    {
+      "repo": "aerospike-cluster-manager",
+      "number": 401,
+      "title": "feat(ui): apply Naver green theme via local tokens/theme/preset CSS",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/401",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-26T06:33:44Z",
+      "state": "MERGED"
+    },
+    {
+      "repo": "aerospike-py",
+      "number": 380,
+      "title": "docs(i18n/ko): re-sync Korean translations against current English source",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/380",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-26T06:03:43Z",
+      "state": "MERGED"
+    },
+    {
+      "repo": "aerospike-py",
+      "number": 379,
+      "title": "refactor(benchmark): rewrite as 5-scenario uvicorn ASGI compare suite",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/379",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-26T01:59:47Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-cluster-manager",
+      "number": 400,
+      "title": "docs: align split container image guidance",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/400",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-26T00:15:18Z",
+      "state": "MERGED"
+    },
+    {
+      "repo": "ackoctl",
+      "number": 54,
+      "title": "fix: preserve default HTTP transport settings",
+      "url": "https://github.com/aerospike-ce-ecosystem/ackoctl/pull/54",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-26T00:15:17Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-ce-kubernetes-operator",
+      "number": 296,
+      "title": "docs: fix CRD chart URL in Helm notes",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/pull/296",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-26T00:15:17Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-py",
+      "number": 378,
+      "title": "docs: sync FastAPI sample defaults",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/378",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-26T00:15:17Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-cluster-manager",
+      "number": 399,
+      "title": "chore(deps-dev): bump @vitest/coverage-v8 from 4.1.6 to 4.1.7 in /ui",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/399",
+      "author": "app/dependabot",
+      "createdAt": "2026-05-25T16:41:01Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-cluster-manager",
+      "number": 398,
+      "title": "chore(deps): bump next from 14.2.23 to 14.2.35 in /ui",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/398",
+      "author": "app/dependabot",
+      "createdAt": "2026-05-25T16:40:48Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-cluster-manager",
+      "number": 397,
+      "title": "chore(deps-dev): bump @types/node from 22.19.17 to 22.19.19 in /ui",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/397",
+      "author": "app/dependabot",
+      "createdAt": "2026-05-25T16:40:20Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-cluster-manager",
+      "number": 396,
+      "title": "chore(deps): bump react-dom from 18.2.0 to 18.3.1 in /ui",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/396",
+      "author": "app/dependabot",
+      "createdAt": "2026-05-25T16:40:05Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-cluster-manager",
+      "number": 395,
+      "title": "chore(deps-dev): bump @typescript-eslint/parser from 8.59.1 to 8.59.4 in /ui",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/395",
+      "author": "app/dependabot",
+      "createdAt": "2026-05-25T16:39:54Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "ackoctl",
+      "number": 53,
+      "title": "docs: refresh CLI docs and install examples",
+      "url": "https://github.com/aerospike-ce-ecosystem/ackoctl/pull/53",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-25T03:31:32Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "project-hub",
+      "number": 102,
+      "title": "docs: sync ADR index and repo inventory",
+      "url": "https://github.com/aerospike-ce-ecosystem/project-hub/pull/102",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-25T03:31:32Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-ce-ecosystem-plugins",
+      "number": 52,
+      "title": "fix: tighten plugin docs and link checks",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/pull/52",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-25T03:31:32Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-ce-kubernetes-operator",
+      "number": 295,
+      "title": "fix: report ConfigDegraded phase metrics",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/pull/295",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-25T03:31:32Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-cluster-manager",
+      "number": 394,
+      "title": "fix: align UI test dependency peers",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/394",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-25T03:31:32Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-py",
+      "number": 377,
+      "title": "test: align feasibility test config with env",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/377",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-25T03:31:32Z",
+      "state": "MERGED"
+    },
+    {
+      "repo": "workspace",
+      "number": 17,
+      "title": "fix: enable scheduled submodule bumps",
+      "url": "https://github.com/aerospike-ce-ecosystem/workspace/pull/17",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-24T12:34:52Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "project-hub",
+      "number": 101,
+      "title": "docs: refresh ecosystem release and plugin docs",
+      "url": "https://github.com/aerospike-ce-ecosystem/project-hub/pull/101",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-24T12:34:52Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "ackoctl",
+      "number": 52,
+      "title": "docs: refresh README command surface",
+      "url": "https://github.com/aerospike-ce-ecosystem/ackoctl/pull/52",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-24T12:34:27Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-ce-kubernetes-operator",
+      "number": 294,
+      "title": "fix: restore kustomize image placeholder",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/pull/294",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-24T12:34:27Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-cluster-manager",
+      "number": 393,
+      "title": "fix: pass KEK env through compose",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/393",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-24T12:34:27Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-py",
+      "number": 376,
+      "title": "fix: honor Aerospike env in feasibility tests",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/376",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-24T12:34:27Z",
+      "state": "CLOSED"
+    },
+    {
+      "repo": "aerospike-py",
+      "number": 375,
+      "title": "feat(rust): free-threaded build + batch_to_dict_py per-stage timing",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/375",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-24T11:37:36Z",
+      "state": "MERGED"
+    },
+    {
+      "repo": "project-hub",
+      "number": 100,
+      "title": "docs(adr): ADR-0052 — aerospike-py batch_read profiling + LazyBatchRecords/to_numpy GIL-detach validation",
+      "url": "https://github.com/aerospike-ce-ecosystem/project-hub/pull/100",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-23T17:37:49Z",
+      "state": "MERGED"
+    },
+    {
+      "repo": "aerospike-ce-ecosystem-plugins",
+      "number": 50,
+      "title": "feat(skills): align aerospike-py SKILLs with LazyBatchRecords + to_numpy/to_dict",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/pull/50",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-23T17:12:52Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-py",
+      "number": 374,
+      "title": "feat!: LazyBatchRecords handle + GIL-detach to_numpy(dtype)",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/374",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-23T16:43:36Z",
+      "state": "MERGED"
+    },
+    {
+      "repo": "aerospike-cluster-manager",
+      "number": 392,
+      "title": "fix: extend bin-name validation to remaining models and UI dialogs",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/392",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-23T02:29:35Z",
+      "state": "MERGED"
+    },
+    {
+      "repo": "aerospike-py",
+      "number": 373,
+      "title": "fix: require list/map BY_VALUE ops to specify 'val' to prevent silent Nil substitution",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/373",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-23T02:28:59Z",
+      "state": "MERGED"
+    }
+  ]
+}

--- a/docs/src/data/pr-stats.json
+++ b/docs/src/data/pr-stats.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2026-05-27T03:02:24.478Z",
+  "generatedAt": "2026-05-27T03:13:42.741Z",
   "org": "aerospike-ce-ecosystem",
   "earliest": "2026-02-05T15:28:20.000Z",
-  "latest": "2026-05-26T06:33:44.000Z",
-  "totalPrs": 986,
+  "latest": "2026-05-27T03:08:25.000Z",
+  "totalPrs": 987,
   "repos": [
     "aerospike-py",
     "aerospike-cluster-manager",
@@ -19,7 +19,7 @@
     "aerospike-cluster-manager": 350,
     "aerospike-ce-kubernetes-operator": 210,
     "ackoctl": 48,
-    "project-hub": 45,
+    "project-hub": 46,
     "aerospike-ce-ecosystem-plugins": 34,
     "workspace": 17,
     ".github": 4
@@ -52,11 +52,11 @@
     "3월 2주차",
     "3월 3주차",
     "3월 4주차",
-    "3월 5주차",
     "4월 1주차",
     "4월 2주차",
     "4월 3주차",
     "4월 4주차",
+    "4월 5주차",
     "5월 1주차",
     "5월 2주차",
     "5월 3주차",
@@ -175,7 +175,7 @@
       2,
       1,
       7,
-      1
+      2
     ],
     "aerospike-ce-ecosystem-plugins": [
       0,
@@ -252,7 +252,7 @@
     106,
     75,
     110,
-    18
+    19
   ],
   "recent4Weeks": [
     "2026-W19",
@@ -260,22 +260,22 @@
     "2026-W21",
     "2026-W22"
   ],
-  "recent4Total": 309,
+  "recent4Total": 310,
   "peakWeek": {
     "week": "2026-W21",
     "korean": "5월 3주차",
     "count": 110
   },
-  "avgPerWeek": 58,
+  "avgPerWeek": 58.06,
   "stateCounts": {
     "MERGED": 885,
-    "OPEN": 20,
-    "CLOSED": 81
+    "CLOSED": 81,
+    "OPEN": 21
   },
   "topContributors": [
     {
       "name": "KimSoungRyoul",
-      "count": 847
+      "count": 848
     },
     {
       "name": "app/dependabot",
@@ -305,10 +305,19 @@
     },
     {
       "month": "2026-05",
-      "count": 334
+      "count": 335
     }
   ],
   "recentPrs": [
+    {
+      "repo": "project-hub",
+      "number": 104,
+      "title": "feat: add weekly PR activity dashboard to home page",
+      "url": "https://github.com/aerospike-ce-ecosystem/project-hub/pull/104",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-27T03:08:25Z",
+      "state": "OPEN"
+    },
     {
       "repo": "aerospike-cluster-manager",
       "number": 401,
@@ -346,10 +355,10 @@
       "state": "MERGED"
     },
     {
-      "repo": "ackoctl",
-      "number": 54,
-      "title": "fix: preserve default HTTP transport settings",
-      "url": "https://github.com/aerospike-ce-ecosystem/ackoctl/pull/54",
+      "repo": "aerospike-py",
+      "number": 378,
+      "title": "docs: sync FastAPI sample defaults",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/378",
       "author": "KimSoungRyoul",
       "createdAt": "2026-05-26T00:15:17Z",
       "state": "OPEN"
@@ -364,10 +373,10 @@
       "state": "OPEN"
     },
     {
-      "repo": "aerospike-py",
-      "number": 378,
-      "title": "docs: sync FastAPI sample defaults",
-      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/378",
+      "repo": "ackoctl",
+      "number": 54,
+      "title": "fix: preserve default HTTP transport settings",
+      "url": "https://github.com/aerospike-ce-ecosystem/ackoctl/pull/54",
       "author": "KimSoungRyoul",
       "createdAt": "2026-05-26T00:15:17Z",
       "state": "OPEN"
@@ -418,28 +427,19 @@
       "state": "OPEN"
     },
     {
-      "repo": "ackoctl",
-      "number": 53,
-      "title": "docs: refresh CLI docs and install examples",
-      "url": "https://github.com/aerospike-ce-ecosystem/ackoctl/pull/53",
+      "repo": "aerospike-py",
+      "number": 377,
+      "title": "test: align feasibility test config with env",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/377",
       "author": "KimSoungRyoul",
       "createdAt": "2026-05-25T03:31:32Z",
-      "state": "OPEN"
+      "state": "MERGED"
     },
     {
-      "repo": "project-hub",
-      "number": 102,
-      "title": "docs: sync ADR index and repo inventory",
-      "url": "https://github.com/aerospike-ce-ecosystem/project-hub/pull/102",
-      "author": "KimSoungRyoul",
-      "createdAt": "2026-05-25T03:31:32Z",
-      "state": "OPEN"
-    },
-    {
-      "repo": "aerospike-ce-ecosystem-plugins",
-      "number": 52,
-      "title": "fix: tighten plugin docs and link checks",
-      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/pull/52",
+      "repo": "aerospike-cluster-manager",
+      "number": 394,
+      "title": "fix: align UI test dependency peers",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/394",
       "author": "KimSoungRyoul",
       "createdAt": "2026-05-25T03:31:32Z",
       "state": "OPEN"
@@ -454,30 +454,30 @@
       "state": "OPEN"
     },
     {
-      "repo": "aerospike-cluster-manager",
-      "number": 394,
-      "title": "fix: align UI test dependency peers",
-      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/394",
+      "repo": "aerospike-ce-ecosystem-plugins",
+      "number": 52,
+      "title": "fix: tighten plugin docs and link checks",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/pull/52",
       "author": "KimSoungRyoul",
       "createdAt": "2026-05-25T03:31:32Z",
       "state": "OPEN"
     },
     {
-      "repo": "aerospike-py",
-      "number": 377,
-      "title": "test: align feasibility test config with env",
-      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/377",
+      "repo": "project-hub",
+      "number": 102,
+      "title": "docs: sync ADR index and repo inventory",
+      "url": "https://github.com/aerospike-ce-ecosystem/project-hub/pull/102",
       "author": "KimSoungRyoul",
       "createdAt": "2026-05-25T03:31:32Z",
-      "state": "MERGED"
+      "state": "OPEN"
     },
     {
-      "repo": "workspace",
-      "number": 17,
-      "title": "fix: enable scheduled submodule bumps",
-      "url": "https://github.com/aerospike-ce-ecosystem/workspace/pull/17",
+      "repo": "ackoctl",
+      "number": 53,
+      "title": "docs: refresh CLI docs and install examples",
+      "url": "https://github.com/aerospike-ce-ecosystem/ackoctl/pull/53",
       "author": "KimSoungRyoul",
-      "createdAt": "2026-05-24T12:34:52Z",
+      "createdAt": "2026-05-25T03:31:32Z",
       "state": "OPEN"
     },
     {
@@ -490,10 +490,28 @@
       "state": "OPEN"
     },
     {
-      "repo": "ackoctl",
-      "number": 52,
-      "title": "docs: refresh README command surface",
-      "url": "https://github.com/aerospike-ce-ecosystem/ackoctl/pull/52",
+      "repo": "workspace",
+      "number": 17,
+      "title": "fix: enable scheduled submodule bumps",
+      "url": "https://github.com/aerospike-ce-ecosystem/workspace/pull/17",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-24T12:34:52Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "aerospike-py",
+      "number": 376,
+      "title": "fix: honor Aerospike env in feasibility tests",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/376",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-24T12:34:27Z",
+      "state": "CLOSED"
+    },
+    {
+      "repo": "aerospike-cluster-manager",
+      "number": 393,
+      "title": "fix: pass KEK env through compose",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/393",
       "author": "KimSoungRyoul",
       "createdAt": "2026-05-24T12:34:27Z",
       "state": "OPEN"
@@ -508,22 +526,13 @@
       "state": "OPEN"
     },
     {
-      "repo": "aerospike-cluster-manager",
-      "number": 393,
-      "title": "fix: pass KEK env through compose",
-      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/393",
+      "repo": "ackoctl",
+      "number": 52,
+      "title": "docs: refresh README command surface",
+      "url": "https://github.com/aerospike-ce-ecosystem/ackoctl/pull/52",
       "author": "KimSoungRyoul",
       "createdAt": "2026-05-24T12:34:27Z",
       "state": "OPEN"
-    },
-    {
-      "repo": "aerospike-py",
-      "number": 376,
-      "title": "fix: honor Aerospike env in feasibility tests",
-      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/376",
-      "author": "KimSoungRyoul",
-      "createdAt": "2026-05-24T12:34:27Z",
-      "state": "CLOSED"
     },
     {
       "repo": "aerospike-py",
@@ -568,15 +577,6 @@
       "url": "https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/392",
       "author": "KimSoungRyoul",
       "createdAt": "2026-05-23T02:29:35Z",
-      "state": "MERGED"
-    },
-    {
-      "repo": "aerospike-py",
-      "number": 373,
-      "title": "fix: require list/map BY_VALUE ops to specify 'val' to prevent silent Nil substitution",
-      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/373",
-      "author": "KimSoungRyoul",
-      "createdAt": "2026-05-23T02:28:59Z",
       "state": "MERGED"
     }
   ]

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -1,0 +1,118 @@
+/* Hero ─────────────────────────────────────────────── */
+.hero {
+  background:
+    radial-gradient(1200px 480px at 50% -10%, color-mix(in srgb, var(--ifm-color-primary) 22%, transparent), transparent 60%),
+    var(--ifm-background-color);
+  padding: 4.5rem 0 5rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-content);
+}
+.heroInner {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  max-width: 880px;
+}
+.heroEyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #e11d48 10%, transparent);
+  color: #e11d48;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+.heroEyebrow::before {
+  content: '';
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: #e11d48;
+}
+.heroTitle {
+  margin: 8px 0 0;
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  line-height: 1.1;
+}
+.heroSubtitle {
+  margin: 0;
+  font-size: 1.2rem;
+  color: var(--ifm-color-content-secondary);
+  font-weight: 500;
+}
+.heroLead {
+  margin: 8px 0 0;
+  font-size: 1rem;
+  color: var(--ifm-color-emphasis-700);
+  max-width: 700px;
+  line-height: 1.65;
+}
+.heroCtas {
+  display: flex;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+/* Sections ─────────────────────────────────────────── */
+.mainWrap { padding-bottom: 4rem; }
+.section { padding: 3rem 0 1rem; }
+.sectionHead { margin-bottom: 1.5rem; }
+.sectionHead h2 {
+  font-size: 1.6rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 6px;
+}
+.sectionDesc {
+  color: var(--ifm-color-content-secondary);
+  margin: 0;
+  font-size: 14px;
+  max-width: 680px;
+  line-height: 1.6;
+}
+
+/* Repo cards ──────────────────────────────────────── */
+.repoCol { margin-bottom: 1rem; }
+.repoCard {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-card-background-color);
+  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+}
+.repoCard:hover {
+  transform: translateY(-2px);
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 6px 20px color-mix(in srgb, var(--ifm-color-primary) 12%, transparent);
+}
+.repoName {
+  margin: 0 0 4px;
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.repoTech {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ifm-color-primary);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+.repoDesc {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--ifm-color-content-secondary);
+}
+.repoFooter {
+  display: flex;
+  gap: 8px;
+  margin-top: auto;
+}

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -2,6 +2,8 @@ import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
+import HomeStats from '@site/src/components/HomeStats';
+import styles from './index.module.css';
 
 const repos = [
   {
@@ -26,9 +28,16 @@ const repos = [
     github: 'https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager',
   },
   {
+    name: 'ackoctl',
+    description: 'cluster-manager CLI · Aerospike 운영 자동화',
+    tech: 'Go / cobra',
+    docs: null,
+    github: 'https://github.com/aerospike-ce-ecosystem/ackoctl',
+  },
+  {
     name: 'Plugins',
-    description: 'Claude Code 에코시스템 플러그인',
-    tech: 'Skills / Agents',
+    description: 'Claude Code 에코시스템 플러그인 (9 skills)',
+    tech: 'Claude Code',
     docs: null,
     github: 'https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins',
   },
@@ -37,13 +46,20 @@ const repos = [
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
   return (
-    <header className={clsx('hero hero--primary')} style={{padding: '4rem 0'}}>
-      <div className="container">
-        <h1 className="hero__title">{siteConfig.title}</h1>
-        <p className="hero__subtitle">{siteConfig.tagline}</p>
-        <div>
-          <Link className="button button--secondary button--lg" to="/docs/intro">
+    <header className={clsx('hero', styles.hero)}>
+      <div className={clsx('container', styles.heroInner)}>
+        <span className={styles.heroEyebrow}>Aerospike CE Ecosystem</span>
+        <h1 className={styles.heroTitle}>{siteConfig.title}</h1>
+        <p className={styles.heroSubtitle}>{siteConfig.tagline}</p>
+        <p className={styles.heroLead}>
+          Aerospike CE를 위한 모던 Python 클라이언트 · Kubernetes Operator · 웹 UI · CLI · AI 개발 도구를 한 곳에서.
+        </p>
+        <div className={styles.heroCtas}>
+          <Link className="button button--primary button--lg" to="/docs/intro">
             Get Started
+          </Link>
+          <Link className="button button--secondary button--lg" to="https://github.com/aerospike-ce-ecosystem">
+            GitHub Org
           </Link>
         </div>
       </div>
@@ -53,17 +69,17 @@ function HomepageHeader() {
 
 function RepoCard({name, description, tech, docs, github}: (typeof repos)[0]) {
   return (
-    <div className="col col--3" style={{marginBottom: '1rem'}}>
-      <div className="card" style={{height: '100%'}}>
+    <div className={clsx('col col--4', styles.repoCol)}>
+      <div className={clsx('card', styles.repoCard)}>
         <div className="card__header">
-          <h3>{name}</h3>
+          <h3 className={styles.repoName}>{name}</h3>
+          <p className={styles.repoTech}>{tech}</p>
         </div>
         <div className="card__body">
-          <p>{description}</p>
-          <p><small>{tech}</small></p>
+          <p className={styles.repoDesc}>{description}</p>
         </div>
-        <div className="card__footer">
-          <a href={github} className="button button--outline button--primary button--sm" style={{marginRight: '0.5rem'}}>
+        <div className={clsx('card__footer', styles.repoFooter)}>
+          <a href={github} className="button button--outline button--primary button--sm">
             GitHub
           </a>
           {docs && (
@@ -77,20 +93,30 @@ function RepoCard({name, description, tech, docs, github}: (typeof repos)[0]) {
   );
 }
 
-export default function Home(): JSX.Element {
+export default function Home(): React.JSX.Element {
   return (
-    <Layout description="Aerospike CE Ecosystem Project Hub">
+    <Layout
+      title="Aerospike CE Ecosystem Hub"
+      description="Aerospike CE 생태계 — Python 클라이언트, Kubernetes Operator, Cluster Manager, ackoctl, Plugins를 위한 단일 허브"
+    >
       <HomepageHeader />
-      <main>
-        <section style={{padding: '2rem 0'}}>
-          <div className="container">
+      <main className={styles.mainWrap}>
+        <section className={clsx('container', styles.section)}>
+          <div className={styles.sectionHead}>
             <h2>Core Repositories</h2>
-            <div className="row">
-              {repos.map((repo) => (
-                <RepoCard key={repo.name} {...repo} />
-              ))}
-            </div>
+            <p className={styles.sectionDesc}>
+              생태계를 구성하는 핵심 리포지토리. 각 프로젝트는 독립적으로 사용할 수 있도록 느슨하게 결합되어 있습니다.
+            </p>
           </div>
+          <div className="row">
+            {repos.map((repo) => (
+              <RepoCard key={repo.name} {...repo} />
+            ))}
+          </div>
+        </section>
+
+        <section className={clsx('container', styles.section)}>
+          <HomeStats />
         </section>
       </main>
     </Layout>

--- a/scripts/collect-pr-stats.mjs
+++ b/scripts/collect-pr-stats.mjs
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+/**
+ * Collect weekly PR statistics for the aerospike-ce-ecosystem org.
+ *
+ * Output: docs/src/data/pr-stats.json
+ *
+ * Requirements:
+ *   - GitHub CLI (gh) authenticated, OR GH_TOKEN env var
+ *   - Node.js >= 20
+ *
+ * Usage:
+ *   node scripts/collect-pr-stats.mjs
+ *   node scripts/collect-pr-stats.mjs --weeks 26   # limit to last N weeks
+ */
+
+import {execFile} from 'node:child_process';
+import {promisify} from 'node:util';
+import {writeFile, mkdir} from 'node:fs/promises';
+import {dirname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const OUT_PATH = join(REPO_ROOT, 'docs/src/data/pr-stats.json');
+
+const ORG = 'aerospike-ce-ecosystem';
+const PER_REPO_LIMIT = 1000;
+
+// Display ordering — keep stable across runs even as activity shifts
+const REPO_ORDER = [
+  'aerospike-py',
+  'aerospike-cluster-manager',
+  'aerospike-ce-kubernetes-operator',
+  'ackoctl',
+  'project-hub',
+  'aerospike-ce-ecosystem-plugins',
+  'workspace',
+  'aerospike-ce-ui-kit',
+  'aerospike-py-performance-report',
+  'homebrew-tap',
+  '.github',
+];
+
+/** Parse `--key value` style CLI args. */
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i++) {
+    const k = argv[i];
+    if (k.startsWith('--')) {
+      const key = k.slice(2);
+      const v = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[++i] : true;
+      out[key] = v;
+    }
+  }
+  return out;
+}
+
+/**
+ * Compute ISO week label, e.g. "2026-W21" — Thursday-of-week rule.
+ * Matches Python's `datetime.isocalendar()` so cross-language tooling agrees.
+ */
+function isoWeekLabel(date) {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  // Thursday in current week decides the year
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNo = Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, '0')}`;
+}
+
+/** Monday date for an ISO week label. */
+function isoWeekStart(label) {
+  const [y, w] = label.split('-W').map(Number);
+  // Jan 4th is always in week 1
+  const jan4 = new Date(Date.UTC(y, 0, 4));
+  const jan4Day = jan4.getUTCDay() || 7;
+  const week1Monday = new Date(jan4);
+  week1Monday.setUTCDate(jan4.getUTCDate() - jan4Day + 1);
+  const monday = new Date(week1Monday);
+  monday.setUTCDate(week1Monday.getUTCDate() + (w - 1) * 7);
+  return monday;
+}
+
+function isoWeekEnd(label) {
+  const start = isoWeekStart(label);
+  const end = new Date(start);
+  end.setUTCDate(start.getUTCDate() + 6);
+  return end;
+}
+
+/** "5월 1주차" — week number is computed from the Monday's day-of-month. */
+function koreanWeekLabel(isoLabel) {
+  const m = isoWeekStart(isoLabel);
+  const weekInMonth = Math.floor((m.getUTCDate() - 1) / 7) + 1;
+  return `${m.getUTCMonth() + 1}월 ${weekInMonth}주차`;
+}
+
+function dateRangeLabel(isoLabel) {
+  const s = isoWeekStart(isoLabel);
+  const e = isoWeekEnd(isoLabel);
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${s.getUTCMonth() + 1}/${pad(s.getUTCDate())}–${e.getUTCMonth() + 1}/${pad(e.getUTCDate())}`;
+}
+
+async function gh(args) {
+  try {
+    const {stdout} = await execFileAsync('gh', args, {maxBuffer: 64 * 1024 * 1024});
+    return stdout;
+  } catch (err) {
+    const msg = err.stderr || err.message;
+    throw new Error(`gh ${args.join(' ')} failed: ${msg}`);
+  }
+}
+
+async function listRepos() {
+  const raw = await gh([
+    'api',
+    `orgs/${ORG}/repos?per_page=100&type=public`,
+    '--jq',
+    '.[] | {name: .name, archived: .archived, fork: .fork}',
+  ]);
+  const lines = raw.trim().split('\n').filter(Boolean);
+  return lines.map((l) => JSON.parse(l)).filter((r) => !r.archived && !r.fork);
+}
+
+async function fetchRepoPrs(repo) {
+  const raw = await gh([
+    'pr',
+    'list',
+    '--repo',
+    `${ORG}/${repo}`,
+    '--state',
+    'all',
+    '--limit',
+    String(PER_REPO_LIMIT),
+    '--json',
+    'number,createdAt,author,state,mergedAt,title,url',
+  ]);
+  return JSON.parse(raw);
+}
+
+function buildAxis(allWeeks) {
+  if (allWeeks.size === 0) return [];
+  const sorted = [...allWeeks].sort();
+  const first = isoWeekStart(sorted[0]);
+  const last = isoWeekStart(sorted[sorted.length - 1]);
+  const axis = [];
+  for (let cur = new Date(first); cur <= last; cur.setUTCDate(cur.getUTCDate() + 7)) {
+    axis.push(isoWeekLabel(cur));
+  }
+  return axis;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const weeksLimit = args.weeks ? Number(args.weeks) : null;
+
+  console.error(`Listing repos for org "${ORG}"…`);
+  const repos = await listRepos();
+  console.error(`Found ${repos.length} repos.`);
+
+  const allPrs = []; // {repo, number, createdAt, author, state, mergedAt, title, url}
+  for (const r of repos) {
+    process.stderr.write(`  ${r.name}: `);
+    try {
+      const prs = await fetchRepoPrs(r.name);
+      for (const pr of prs) allPrs.push({...pr, repo: r.name});
+      process.stderr.write(`${prs.length} PRs\n`);
+    } catch (e) {
+      process.stderr.write(`error (${e.message})\n`);
+    }
+  }
+
+  const activeRepos = REPO_ORDER.filter((r) =>
+    allPrs.some((p) => p.repo === r)
+  );
+
+  const perRepoWeekly = new Map();
+  const allWeeks = new Set();
+  const authorCounter = new Map();
+  const stateCounter = new Map();
+  const monthlyTotal = new Map();
+  const recentPrs = [];
+  let earliest = null;
+  let latest = null;
+
+  for (const pr of allPrs) {
+    if (!activeRepos.includes(pr.repo)) continue;
+    const created = new Date(pr.createdAt);
+    const week = isoWeekLabel(created);
+    allWeeks.add(week);
+
+    if (!perRepoWeekly.has(pr.repo)) perRepoWeekly.set(pr.repo, new Map());
+    const map = perRepoWeekly.get(pr.repo);
+    map.set(week, (map.get(week) || 0) + 1);
+
+    const login = pr.author?.login || 'unknown';
+    authorCounter.set(login, (authorCounter.get(login) || 0) + 1);
+
+    const effectiveState = pr.mergedAt ? 'MERGED' : pr.state;
+    stateCounter.set(effectiveState, (stateCounter.get(effectiveState) || 0) + 1);
+
+    const month = `${created.getUTCFullYear()}-${String(created.getUTCMonth() + 1).padStart(2, '0')}`;
+    monthlyTotal.set(month, (monthlyTotal.get(month) || 0) + 1);
+
+    if (!earliest || created < earliest) earliest = created;
+    if (!latest || created > latest) latest = created;
+
+    recentPrs.push({
+      repo: pr.repo,
+      number: pr.number,
+      title: pr.title,
+      url: pr.url,
+      author: login,
+      createdAt: pr.createdAt,
+      state: effectiveState,
+    });
+  }
+
+  let weeksAxis = buildAxis(allWeeks);
+  if (weeksLimit && weeksAxis.length > weeksLimit) {
+    weeksAxis = weeksAxis.slice(-weeksLimit);
+  }
+
+  const repoSeries = {};
+  for (const r of activeRepos) {
+    repoSeries[r] = weeksAxis.map((w) => perRepoWeekly.get(r)?.get(w) || 0);
+  }
+
+  const totalPerWeek = weeksAxis.map((_, i) =>
+    activeRepos.reduce((sum, r) => sum + repoSeries[r][i], 0)
+  );
+  const totalPrs = totalPerWeek.reduce((s, v) => s + v, 0);
+
+  const recent4 = weeksAxis.slice(-4);
+  const recent4Total = recent4.reduce(
+    (s, w) => s + activeRepos.reduce((rs, r) => rs + (perRepoWeekly.get(r)?.get(w) || 0), 0),
+    0
+  );
+
+  let peakWeek = null;
+  let peakCount = 0;
+  weeksAxis.forEach((w, i) => {
+    if (totalPerWeek[i] > peakCount) {
+      peakWeek = w;
+      peakCount = totalPerWeek[i];
+    }
+  });
+
+  const perRepoTotal = Object.fromEntries(
+    activeRepos.map((r) => [r, Object.values(repoSeries[r]).reduce((s, v) => s + v, 0)])
+  );
+
+  recentPrs.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+
+  const topContributors = [...authorCounter.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 15)
+    .map(([name, count]) => ({name, count}));
+
+  const monthly = [...monthlyTotal.entries()]
+    .sort((a, b) => (a[0] < b[0] ? -1 : 1))
+    .map(([month, count]) => ({month, count}));
+
+  const out = {
+    generatedAt: new Date().toISOString(),
+    org: ORG,
+    earliest: earliest?.toISOString() || null,
+    latest: latest?.toISOString() || null,
+    totalPrs,
+    repos: activeRepos,
+    perRepoTotal,
+    weeksAxis,
+    weeksKorean: weeksAxis.map(koreanWeekLabel),
+    weeksDateRange: weeksAxis.map(dateRangeLabel),
+    repoSeries,
+    totalPerWeek,
+    recent4Weeks: recent4,
+    recent4Total,
+    peakWeek: peakWeek ? {week: peakWeek, korean: koreanWeekLabel(peakWeek), count: peakCount} : null,
+    avgPerWeek: weeksAxis.length ? Number((totalPrs / weeksAxis.length).toFixed(2)) : 0,
+    stateCounts: Object.fromEntries(stateCounter),
+    topContributors,
+    monthly,
+    recentPrs: recentPrs.slice(0, 30),
+  };
+
+  await mkdir(dirname(OUT_PATH), {recursive: true});
+  await writeFile(OUT_PATH, JSON.stringify(out, null, 2) + '\n');
+  console.error(`\nWrote ${OUT_PATH}`);
+  console.error(`  ${totalPrs} PRs across ${weeksAxis.length} weeks (${activeRepos.length} active repos)`);
+  console.error(`  peak: ${out.peakWeek?.korean} (${peakCount})  avg/week: ${out.avgPerWeek}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/collect-pr-stats.mjs
+++ b/scripts/collect-pr-stats.mjs
@@ -90,11 +90,17 @@ function isoWeekEnd(label) {
   return end;
 }
 
-/** "5월 1주차" — week number is computed from the Monday's day-of-month. */
+/**
+ * "5월 1주차" — Thursday-of-week determines which month the week belongs to,
+ * matching the ISO 8601 convention used to assign weeks to years. For a week
+ * that straddles a month boundary, the side with 4+ days wins (Mon–Thu rule).
+ */
 function koreanWeekLabel(isoLabel) {
-  const m = isoWeekStart(isoLabel);
-  const weekInMonth = Math.floor((m.getUTCDate() - 1) / 7) + 1;
-  return `${m.getUTCMonth() + 1}월 ${weekInMonth}주차`;
+  const monday = isoWeekStart(isoLabel);
+  const thu = new Date(monday);
+  thu.setUTCDate(monday.getUTCDate() + 3);
+  const weekInMonth = Math.floor((thu.getUTCDate() - 1) / 7) + 1;
+  return `${thu.getUTCMonth() + 1}월 ${weekInMonth}주차`;
 }
 
 function dateRangeLabel(isoLabel) {
@@ -177,8 +183,27 @@ async function main() {
     allPrs.some((p) => p.repo === r)
   );
 
-  const perRepoWeekly = new Map();
+  // First pass: bucket PRs by ISO week so we know the axis range.
   const allWeeks = new Set();
+  const prsByWeek = new Map(); // week -> [pr, ...]
+  for (const pr of allPrs) {
+    if (!activeRepos.includes(pr.repo)) continue;
+    const week = isoWeekLabel(new Date(pr.createdAt));
+    allWeeks.add(week);
+    if (!prsByWeek.has(week)) prsByWeek.set(week, []);
+    prsByWeek.get(week).push(pr);
+  }
+
+  let weeksAxis = buildAxis(allWeeks);
+  if (weeksLimit && weeksAxis.length > weeksLimit) {
+    weeksAxis = weeksAxis.slice(-weeksLimit);
+  }
+  const weeksSet = new Set(weeksAxis);
+
+  // Second pass: accumulate ALL stats (counters, recent, etc.) only over PRs
+  // whose week is included in weeksAxis. Keeps every exported number consistent
+  // with the visualised window — critical when `--weeks N` is supplied.
+  const perRepoWeekly = new Map();
   const authorCounter = new Map();
   const stateCounter = new Map();
   const monthlyTotal = new Map();
@@ -186,42 +211,36 @@ async function main() {
   let earliest = null;
   let latest = null;
 
-  for (const pr of allPrs) {
-    if (!activeRepos.includes(pr.repo)) continue;
-    const created = new Date(pr.createdAt);
-    const week = isoWeekLabel(created);
-    allWeeks.add(week);
+  for (const week of weeksAxis) {
+    for (const pr of prsByWeek.get(week) ?? []) {
+      const created = new Date(pr.createdAt);
 
-    if (!perRepoWeekly.has(pr.repo)) perRepoWeekly.set(pr.repo, new Map());
-    const map = perRepoWeekly.get(pr.repo);
-    map.set(week, (map.get(week) || 0) + 1);
+      if (!perRepoWeekly.has(pr.repo)) perRepoWeekly.set(pr.repo, new Map());
+      const map = perRepoWeekly.get(pr.repo);
+      map.set(week, (map.get(week) || 0) + 1);
 
-    const login = pr.author?.login || 'unknown';
-    authorCounter.set(login, (authorCounter.get(login) || 0) + 1);
+      const login = pr.author?.login || 'unknown';
+      authorCounter.set(login, (authorCounter.get(login) || 0) + 1);
 
-    const effectiveState = pr.mergedAt ? 'MERGED' : pr.state;
-    stateCounter.set(effectiveState, (stateCounter.get(effectiveState) || 0) + 1);
+      const effectiveState = pr.mergedAt ? 'MERGED' : pr.state;
+      stateCounter.set(effectiveState, (stateCounter.get(effectiveState) || 0) + 1);
 
-    const month = `${created.getUTCFullYear()}-${String(created.getUTCMonth() + 1).padStart(2, '0')}`;
-    monthlyTotal.set(month, (monthlyTotal.get(month) || 0) + 1);
+      const month = `${created.getUTCFullYear()}-${String(created.getUTCMonth() + 1).padStart(2, '0')}`;
+      monthlyTotal.set(month, (monthlyTotal.get(month) || 0) + 1);
 
-    if (!earliest || created < earliest) earliest = created;
-    if (!latest || created > latest) latest = created;
+      if (!earliest || created < earliest) earliest = created;
+      if (!latest || created > latest) latest = created;
 
-    recentPrs.push({
-      repo: pr.repo,
-      number: pr.number,
-      title: pr.title,
-      url: pr.url,
-      author: login,
-      createdAt: pr.createdAt,
-      state: effectiveState,
-    });
-  }
-
-  let weeksAxis = buildAxis(allWeeks);
-  if (weeksLimit && weeksAxis.length > weeksLimit) {
-    weeksAxis = weeksAxis.slice(-weeksLimit);
+      recentPrs.push({
+        repo: pr.repo,
+        number: pr.number,
+        title: pr.title,
+        url: pr.url,
+        author: login,
+        createdAt: pr.createdAt,
+        state: effectiveState,
+      });
+    }
   }
 
   const repoSeries = {};
@@ -253,7 +272,9 @@ async function main() {
     activeRepos.map((r) => [r, Object.values(repoSeries[r]).reduce((s, v) => s + v, 0)])
   );
 
-  recentPrs.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+  recentPrs.sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
 
   const topContributors = [...authorCounter.entries()]
     .sort((a, b) => b[1] - a[1])


### PR DESCRIPTION
## Summary

project-hub 메인 페이지 (`/`)에 **org 전체의 주간 PR 활동 대시보드**를 추가합니다.

- **새 KPI 패널** — 총 PR / 평균·주 / 피크 주차 / 최근 4주 / Merge rate
- **주차별 stacked SVG 차트** — 마우스 hover 시 repo별 breakdown tooltip
- **주차 × Repo 매트릭스** — repo별 활동량에 비례한 heatmap 셀
- **State 분포 + Top Contributors** — 한 줄 distribution bar와 horizontal bar
- **최근 PR 30건** — GitHub 링크 포함 테이블

차트는 외부 라이브러리 없이 **pure SVG + CSS modules**로 구현 — Docusaurus light/dark 테마 모두 자동 적응.

## How it stays fresh

- `scripts/collect-pr-stats.mjs` — `gh` CLI 기반 Node 스크립트 (Node 20+)
  - org `aerospike-ce-ecosystem`의 active repo PR을 수집해 `docs/src/data/pr-stats.json`에 기록
  - ISO 주차 산출 + 한글 라벨 (`5월 3주차`) + 날짜 범위 부라벨 생성
- `.github/workflows/weekly-pr-stats.yml` — **매주 월요일 09:00 KST cron**
  - 데이터 갱신 후 자동으로 `bot/weekly-pr-stats` 브랜치에 PR 생성
  - 검토 후 머지하면 메인 페이지가 새 데이터로 빌드됨
  - `workflow_dispatch`로 수동 실행 가능 (옵션: PR 대신 main에 직접 commit)

## Other touches

- 메인 페이지 hero를 다듬고 — eyebrow chip, gradient background, dual CTA
- Core Repositories에 `ackoctl` 추가하고 `col--3 → col--4`로 그리드 조정
- 카드 hover lift 효과로 작은 affordance 추가

## Screenshots

스냅샷 데이터 기준 (집계: 2026-02-02 ~ 2026-05-26):
- Total PRs: **986**
- 평균/주: **58.0** · 피크: **5월 3주차 (110건)**
- Merge rate: **89.4%**

## Test plan

- [x] `npm run typecheck` (docs/) — 통과
- [x] `npm run build` (docs/) — 통과 · 새로운 경고 없음
- [x] 수동으로 `node scripts/collect-pr-stats.mjs` 실행 → 986 PRs / 17주 / 8 repos
- [ ] 메인 페이지 시각 확인 (배포 후)
- [ ] cron workflow 첫 실행 (`workflow_dispatch`로 트리거 가능)

## Notes

- `docs/src/data/pr-stats.json`은 single source of truth — 빌드는 이 파일을 import해서 정적으로 인라인됨
- `peter-evans/create-pull-request@v7` 액션을 사용해 매주 PR을 만듦
- 외부 npm dependency를 추가하지 않음 (번들 사이즈 보존)

🤖 Generated with [Claude Code](https://claude.com/claude-code)