### PR TITLE
refactor(home-stats): translate user-facing strings to English

### DIFF
--- a/.github/workflows/weekly-pr-stats.yml
+++ b/.github/workflows/weekly-pr-stats.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       open_pr:
-        description: 'PR로 열기 (기본). false면 main에 직접 commit'
+        description: 'Open a PR (default). If false, commit directly to main.'
         required: false
         type: boolean
         default: true
@@ -87,15 +87,15 @@ jobs:
           commit-message: 'chore: refresh weekly PR stats'
           title: 'chore: refresh weekly PR stats'
           body: |
-            ## Weekly PR Stats Refresh
+            ## Weekly PR stats refresh
 
             This PR was opened automatically by the `weekly-pr-stats` workflow.
 
             - Source: `node scripts/collect-pr-stats.mjs`
             - Output: `docs/src/data/pr-stats.json`
-            - Schedule: 매주 월요일 09:00 KST
+            - Schedule: every Monday at 00:00 UTC
 
-            데이터를 검토한 뒤 머지하면 메인 페이지의 통계 카드가 갱신됩니다.
+            Review the diff and merge to refresh the home-page stats panel.
           labels: |
             automation
             stats

--- a/docs/src/components/HomeStats/RepoMatrix.tsx
+++ b/docs/src/components/HomeStats/RepoMatrix.tsx
@@ -4,7 +4,7 @@ import styles from './styles.module.css';
 
 interface Props {
   weeksAxis: string[];
-  weeksKorean: string[];
+  weeksDisplay: string[];
   weeksDateRange: string[];
   repos: string[];
   repoSeries: Record<string, number[]>;
@@ -39,7 +39,7 @@ function totalHeatStyle(value: number, max: number): React.CSSProperties {
 
 export default function RepoMatrix({
   weeksAxis,
-  weeksKorean,
+  weeksDisplay,
   weeksDateRange,
   repos,
   repoSeries,
@@ -58,14 +58,14 @@ export default function RepoMatrix({
       <table className={styles.matrix}>
         <thead>
           <tr>
-            <th className={styles.weekHeader}>주차</th>
+            <th className={styles.weekHeader}>Week</th>
             {repos.map((r) => (
               <th key={r} className={styles.repoHeader}>
                 <span className={styles.repoDot} style={{background: repoColor(r)}} />
                 {repoLabel(r)}
               </th>
             ))}
-            <th className={styles.totalHeader}>합계</th>
+            <th className={styles.totalHeader}>Total</th>
           </tr>
         </thead>
         <tbody>
@@ -73,7 +73,7 @@ export default function RepoMatrix({
             <tr key={w}>
               <td className={styles.weekCell}>
                 <div className={styles.weekCellInner}>
-                  <span className={styles.weekMain}>{weeksKorean[i]}</span>
+                  <span className={styles.weekMain}>{weeksDisplay[i]}</span>
                   <span className={styles.weekSub}>{weeksDateRange[i]}</span>
                 </div>
               </td>
@@ -102,7 +102,7 @@ export default function RepoMatrix({
           <tr>
             <td className={styles.weekCell}>
               <div className={styles.weekCellInner}>
-                <span className={styles.weekMain}>전체 합계</span>
+                <span className={styles.weekMain}>Total</span>
               </div>
             </td>
             {repos.map((r) => (

--- a/docs/src/components/HomeStats/WeeklyChart.tsx
+++ b/docs/src/components/HomeStats/WeeklyChart.tsx
@@ -3,7 +3,7 @@ import {repoColor, repoLabel} from './constants';
 import styles from './styles.module.css';
 
 interface Props {
-  weeksKorean: string[];
+  weeksDisplay: string[];
   weeksDateRange: string[];
   weeksAxis: string[];
   repos: string[];
@@ -16,7 +16,7 @@ interface Props {
  * Hover a bar to see per-repo breakdown in the tooltip.
  */
 export default function WeeklyChart({
-  weeksKorean,
+  weeksDisplay,
   weeksDateRange,
   weeksAxis,
   repos,
@@ -50,7 +50,7 @@ export default function WeeklyChart({
         preserveAspectRatio="xMidYMid meet"
         className={styles.chartSvg}
         role="img"
-        aria-label="주차별 PR 생성 추이"
+        aria-label="Weekly PR creation trend"
       >
         {/* Y grid + labels */}
         {yTicks.map((t) => {
@@ -80,7 +80,7 @@ export default function WeeklyChart({
               key={i}
               role="button"
               tabIndex={0}
-              aria-label={`${weeksKorean[i]}, 합계 ${totalPerWeek[i]}건`}
+              aria-label={`${weeksDisplay[i]}, total ${totalPerWeek[i]} PRs`}
               onPointerEnter={() => setHover(i)}
               onPointerLeave={() => setHover(null)}
               onPointerDown={() => setHover(i)}
@@ -119,7 +119,7 @@ export default function WeeklyChart({
         })}
 
         {/* X labels — show every other tick on small viewports via CSS class */}
-        {weeksKorean.map((label, i) => {
+        {weeksDisplay.map((label, i) => {
           const x = M.left + bandWidth * i + bandWidth / 2;
           return (
             <g key={i}>
@@ -153,7 +153,7 @@ export default function WeeklyChart({
           }}
         >
           <div className={styles.tooltipTitle}>
-            {weeksKorean[hover]} <span className={styles.tooltipSub}>· {weeksDateRange[hover]}</span>
+            {weeksDisplay[hover]} <span className={styles.tooltipSub}>· {weeksDateRange[hover]}</span>
           </div>
           {repos
             .map((r) => ({repo: r, count: repoSeries[r]?.[hover] ?? 0}))
@@ -167,7 +167,7 @@ export default function WeeklyChart({
               </div>
             ))}
           <div className={styles.tooltipFooter}>
-            합계 <strong>{totalPerWeek[hover]}</strong>건
+            Total <strong>{totalPerWeek[hover]}</strong>
           </div>
         </div>
       )}

--- a/docs/src/components/HomeStats/index.tsx
+++ b/docs/src/components/HomeStats/index.tsx
@@ -8,15 +8,15 @@ import styles from './styles.module.css';
 
 const data: PrStatsData = statsData as PrStatsData;
 
-function formatDateKr(iso: string | null): string {
+function formatDate(iso: string | null): string {
   if (!iso) return '';
   const d = new Date(iso);
   return `${d.getUTCFullYear()}.${String(d.getUTCMonth() + 1).padStart(2, '0')}.${String(d.getUTCDate()).padStart(2, '0')}`;
 }
 
-function formatGeneratedKr(iso: string): string {
-  // Render in UTC and label it explicitly — formatDateKr also uses UTC, so the
-  // header (집계 ~ / 마지막 업데이트) stays on one consistent timezone.
+function formatGenerated(iso: string): string {
+  // Render in UTC and label it explicitly so the panel header reads on one
+  // consistent timezone (formatDate also uses UTC).
   const d = new Date(iso);
   const y = d.getUTCFullYear();
   const m = String(d.getUTCMonth() + 1).padStart(2, '0');
@@ -67,7 +67,7 @@ function StateBar(): React.JSX.Element {
 function TopContributors(): React.JSX.Element {
   const top = data.topContributors;
   if (top.length === 0) {
-    return <p className={styles.muted}>아직 기여자 데이터가 없습니다.</p>;
+    return <p className={styles.muted}>No contributor data yet.</p>;
   }
   const max = top[0].count || 1;
   const denom = data.totalPrs || 1;
@@ -147,44 +147,44 @@ function StatsPanel(): React.JSX.Element {
       <div className={styles.statsHeader}>
         <div>
           <span className={styles.eyebrow}>ORG Activity</span>
-          <h2 className={styles.statsTitle}>주간 PR 활동 지표</h2>
+          <h2 className={styles.statsTitle}>Weekly PR Activity</h2>
           <p className={styles.statsSub}>
-            <code>{data.org}</code> · 집계 <strong>{formatDateKr(data.earliest)} ~ {formatDateKr(data.latest)}</strong>
+            <code>{data.org}</code> · range <strong>{formatDate(data.earliest)} – {formatDate(data.latest)}</strong>
             <span className={styles.metaDot}>·</span>
-            매주 월요일 09:00 KST 자동 갱신
+            Refreshed every Monday 00:00 UTC
             <span className={styles.metaDot}>·</span>
-            마지막 업데이트 {formatGeneratedKr(data.generatedAt)}
+            Last updated {formatGenerated(data.generatedAt)}
           </p>
         </div>
       </div>
 
       <div className={styles.kpiGrid}>
         <div className={`${styles.kpi} ${styles.kpiAccent}`}>
-          <div className={styles.kpiLabel}>총 PR</div>
+          <div className={styles.kpiLabel}>Total PRs</div>
           <div className={styles.kpiValue}>{data.totalPrs.toLocaleString()}</div>
-          <div className={styles.kpiHint}>{data.repos.length}개 활성 repo</div>
+          <div className={styles.kpiHint}>{data.repos.length} active repos</div>
         </div>
         <div className={styles.kpi}>
-          <div className={styles.kpiLabel}>평균 / 주</div>
+          <div className={styles.kpiLabel}>Avg / week</div>
           <div className={styles.kpiValue}>{data.avgPerWeek.toFixed(1)}</div>
-          <div className={styles.kpiHint}>{data.weeksAxis.length}주 기준</div>
+          <div className={styles.kpiHint}>over {data.weeksAxis.length} weeks</div>
         </div>
         <div className={styles.kpi}>
-          <div className={styles.kpiLabel}>피크 주차</div>
+          <div className={styles.kpiLabel}>Peak week</div>
           <div className={styles.kpiValue}>{data.peakWeek?.count ?? 0}</div>
-          <div className={styles.kpiHint}>{data.peakWeek?.korean ?? '—'}</div>
+          <div className={styles.kpiHint}>{data.peakWeek?.display ?? '—'}</div>
         </div>
         <div className={styles.kpi}>
-          <div className={styles.kpiLabel}>최근 4주</div>
+          <div className={styles.kpiLabel}>Last 4 weeks</div>
           <div className={styles.kpiValue}>{data.recent4Total}</div>
           <div className={styles.kpiHint}>
             {last4.length > 0
-              ? `${data.weeksKorean[data.weeksAxis.indexOf(last4[0])]} ~ ${data.weeksKorean[data.weeksAxis.indexOf(last4[last4.length - 1])]}`
+              ? `${data.weeksDisplay[data.weeksAxis.indexOf(last4[0])]} – ${data.weeksDisplay[data.weeksAxis.indexOf(last4[last4.length - 1])]}`
               : '—'}
           </div>
         </div>
         <div className={styles.kpi}>
-          <div className={styles.kpiLabel}>Merge Rate</div>
+          <div className={styles.kpiLabel}>Merge rate</div>
           <div className={styles.kpiValue}>
             {mergeRate.toFixed(1)}
             <span className={styles.kpiUnit}>%</span>
@@ -195,12 +195,12 @@ function StatsPanel(): React.JSX.Element {
 
       <div className={styles.card}>
         <div className={styles.cardHead}>
-          <h3>주차별 PR 생성 추이</h3>
-          <span className={styles.cardTag}>Repo 누적 · 월·주차 단위</span>
+          <h3>Weekly PR creation trend</h3>
+          <span className={styles.cardTag}>Stacked by repo · month-week buckets</span>
         </div>
-        <p className={styles.cardDesc}>막대에 마우스를 올리면 repo별 세부 카운트를 확인할 수 있습니다.</p>
+        <p className={styles.cardDesc}>Hover (or focus) a bar to see the per-repo breakdown.</p>
         <WeeklyChart
-          weeksKorean={data.weeksKorean}
+          weeksDisplay={data.weeksDisplay}
           weeksDateRange={data.weeksDateRange}
           weeksAxis={data.weeksAxis}
           repos={data.repos}
@@ -222,31 +222,31 @@ function StatsPanel(): React.JSX.Element {
       <div className={styles.row2}>
         <div className={styles.card}>
           <div className={styles.cardHead}>
-            <h3>PR 상태 분포</h3>
-            <span className={styles.cardTag}>{data.totalPrs}건</span>
+            <h3>PR state distribution</h3>
+            <span className={styles.cardTag}>{data.totalPrs} total</span>
           </div>
           <p className={styles.cardDesc}>Merge rate: <strong>{mergeRate.toFixed(1)}%</strong></p>
           <StateBar />
         </div>
         <div className={styles.card}>
           <div className={styles.cardHead}>
-            <h3>Top Contributors</h3>
-            <span className={styles.cardTag}>bot 포함</span>
+            <h3>Top contributors</h3>
+            <span className={styles.cardTag}>bots included</span>
           </div>
-          <p className={styles.cardDesc}>PR 생성자 기준 상위 15명</p>
+          <p className={styles.cardDesc}>Top 15 PR authors</p>
           <TopContributors />
         </div>
       </div>
 
       <div className={styles.card}>
         <div className={styles.cardHead}>
-          <h3>주차 × Repo 매트릭스</h3>
-          <span className={styles.cardTag}>{data.weeksAxis.length}주 × {data.repos.length}개 repo</span>
+          <h3>Week × Repo matrix</h3>
+          <span className={styles.cardTag}>{data.weeksAxis.length} weeks × {data.repos.length} repos</span>
         </div>
-        <p className={styles.cardDesc}>셀 배경 진하기 = 해당 repo 내 상대적 활동량 · <span className={styles.zeroHint}>·</span> 표기는 0건</p>
+        <p className={styles.cardDesc}>Cell shading scales with each repo&apos;s activity for that week · <span className={styles.zeroHint}>·</span> means zero.</p>
         <RepoMatrix
           weeksAxis={data.weeksAxis}
-          weeksKorean={data.weeksKorean}
+          weeksDisplay={data.weeksDisplay}
           weeksDateRange={data.weeksDateRange}
           repos={data.repos}
           repoSeries={data.repoSeries}
@@ -258,10 +258,10 @@ function StatsPanel(): React.JSX.Element {
 
       <div className={styles.card}>
         <div className={styles.cardHead}>
-          <h3>최근 PR</h3>
-          <span className={styles.cardTag}>생성일 내림차순 · 30건</span>
+          <h3>Recent PRs</h3>
+          <span className={styles.cardTag}>Latest 30 · by created date</span>
         </div>
-        <p className={styles.cardDesc}>PR 번호 클릭 시 GitHub에서 열림</p>
+        <p className={styles.cardDesc}>Click a PR number to open it on GitHub.</p>
         <RecentPrs />
       </div>
     </section>

--- a/docs/src/components/HomeStats/types.ts
+++ b/docs/src/components/HomeStats/types.ts
@@ -7,13 +7,13 @@ export interface PrStatsData {
   repos: string[];
   perRepoTotal: Record<string, number>;
   weeksAxis: string[];
-  weeksKorean: string[];
+  weeksDisplay: string[];
   weeksDateRange: string[];
   repoSeries: Record<string, number[]>;
   totalPerWeek: number[];
   recent4Weeks: string[];
   recent4Total: number;
-  peakWeek: {week: string; korean: string; count: number} | null;
+  peakWeek: {week: string; display: string; count: number} | null;
   avgPerWeek: number;
   stateCounts: Record<string, number>;
   topContributors: {name: string; count: number}[];

--- a/docs/src/data/pr-stats.json
+++ b/docs/src/data/pr-stats.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2026-05-27T03:13:42.741Z",
+  "generatedAt": "2026-05-27T03:39:19.258Z",
   "org": "aerospike-ce-ecosystem",
   "earliest": "2026-02-05T15:28:20.000Z",
-  "latest": "2026-05-27T03:08:25.000Z",
-  "totalPrs": 987,
+  "latest": "2026-05-27T03:38:47.000Z",
+  "totalPrs": 990,
   "repos": [
     "aerospike-py",
     "aerospike-cluster-manager",
@@ -15,11 +15,11 @@
     ".github"
   ],
   "perRepoTotal": {
-    "aerospike-py": 278,
+    "aerospike-py": 279,
     "aerospike-cluster-manager": 350,
     "aerospike-ce-kubernetes-operator": 210,
-    "ackoctl": 48,
-    "project-hub": 46,
+    "ackoctl": 49,
+    "project-hub": 47,
     "aerospike-ce-ecosystem-plugins": 34,
     "workspace": 17,
     ".github": 4
@@ -43,43 +43,43 @@
     "2026-W21",
     "2026-W22"
   ],
-  "weeksKorean": [
-    "2월 1주차",
-    "2월 2주차",
-    "2월 3주차",
-    "2월 4주차",
-    "3월 1주차",
-    "3월 2주차",
-    "3월 3주차",
-    "3월 4주차",
-    "4월 1주차",
-    "4월 2주차",
-    "4월 3주차",
-    "4월 4주차",
-    "4월 5주차",
-    "5월 1주차",
-    "5월 2주차",
-    "5월 3주차",
-    "5월 4주차"
+  "weeksDisplay": [
+    "Feb W1",
+    "Feb W2",
+    "Feb W3",
+    "Feb W4",
+    "Mar W1",
+    "Mar W2",
+    "Mar W3",
+    "Mar W4",
+    "Apr W1",
+    "Apr W2",
+    "Apr W3",
+    "Apr W4",
+    "Apr W5",
+    "May W1",
+    "May W2",
+    "May W3",
+    "May W4"
   ],
   "weeksDateRange": [
-    "2/02–2/08",
-    "2/09–2/15",
-    "2/16–2/22",
-    "2/23–3/01",
-    "3/02–3/08",
-    "3/09–3/15",
-    "3/16–3/22",
-    "3/23–3/29",
-    "3/30–4/05",
-    "4/06–4/12",
-    "4/13–4/19",
-    "4/20–4/26",
-    "4/27–5/03",
-    "5/04–5/10",
-    "5/11–5/17",
-    "5/18–5/24",
-    "5/25–5/31"
+    "Feb 02–08",
+    "Feb 09–15",
+    "Feb 16–22",
+    "Feb 23 – Mar 01",
+    "Mar 02–08",
+    "Mar 09–15",
+    "Mar 16–22",
+    "Mar 23–29",
+    "Mar 30 – Apr 05",
+    "Apr 06–12",
+    "Apr 13–19",
+    "Apr 20–26",
+    "Apr 27 – May 03",
+    "May 04–10",
+    "May 11–17",
+    "May 18–24",
+    "May 25–31"
   ],
   "repoSeries": {
     "aerospike-py": [
@@ -99,7 +99,7 @@
       8,
       11,
       18,
-      4
+      5
     ],
     "aerospike-cluster-manager": [
       0,
@@ -156,7 +156,7 @@
       0,
       28,
       18,
-      2
+      3
     ],
     "project-hub": [
       0,
@@ -175,7 +175,7 @@
       2,
       1,
       7,
-      2
+      3
     ],
     "aerospike-ce-ecosystem-plugins": [
       0,
@@ -252,7 +252,7 @@
     106,
     75,
     110,
-    19
+    22
   ],
   "recent4Weeks": [
     "2026-W19",
@@ -260,22 +260,22 @@
     "2026-W21",
     "2026-W22"
   ],
-  "recent4Total": 310,
+  "recent4Total": 313,
   "peakWeek": {
     "week": "2026-W21",
-    "korean": "5월 3주차",
+    "display": "May W3",
     "count": 110
   },
-  "avgPerWeek": 58.06,
+  "avgPerWeek": 58.24,
   "stateCounts": {
-    "MERGED": 885,
+    "MERGED": 886,
     "CLOSED": 81,
-    "OPEN": 21
+    "OPEN": 23
   },
   "topContributors": [
     {
       "name": "KimSoungRyoul",
-      "count": 848
+      "count": 850
     },
     {
       "name": "app/dependabot",
@@ -283,7 +283,7 @@
     },
     {
       "name": "app/github-actions",
-      "count": 4
+      "count": 5
     },
     {
       "name": "app/claude",
@@ -305,10 +305,37 @@
     },
     {
       "month": "2026-05",
-      "count": 335
+      "count": 338
     }
   ],
   "recentPrs": [
+    {
+      "repo": "aerospike-py",
+      "number": 381,
+      "title": "chore(ci): bump GitHub Actions to latest versions",
+      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/381",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-27T03:38:47Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "ackoctl",
+      "number": 55,
+      "title": "chore(ci): bump GitHub Actions to latest major versions",
+      "url": "https://github.com/aerospike-ce-ecosystem/ackoctl/pull/55",
+      "author": "KimSoungRyoul",
+      "createdAt": "2026-05-27T03:37:24Z",
+      "state": "OPEN"
+    },
+    {
+      "repo": "project-hub",
+      "number": 105,
+      "title": "chore: refresh weekly PR stats",
+      "url": "https://github.com/aerospike-ce-ecosystem/project-hub/pull/105",
+      "author": "app/github-actions",
+      "createdAt": "2026-05-27T03:32:54Z",
+      "state": "OPEN"
+    },
     {
       "repo": "project-hub",
       "number": 104,
@@ -316,7 +343,7 @@
       "url": "https://github.com/aerospike-ce-ecosystem/project-hub/pull/104",
       "author": "KimSoungRyoul",
       "createdAt": "2026-05-27T03:08:25Z",
-      "state": "OPEN"
+      "state": "MERGED"
     },
     {
       "repo": "aerospike-cluster-manager",
@@ -550,33 +577,6 @@
       "url": "https://github.com/aerospike-ce-ecosystem/project-hub/pull/100",
       "author": "KimSoungRyoul",
       "createdAt": "2026-05-23T17:37:49Z",
-      "state": "MERGED"
-    },
-    {
-      "repo": "aerospike-ce-ecosystem-plugins",
-      "number": 50,
-      "title": "feat(skills): align aerospike-py SKILLs with LazyBatchRecords + to_numpy/to_dict",
-      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/pull/50",
-      "author": "KimSoungRyoul",
-      "createdAt": "2026-05-23T17:12:52Z",
-      "state": "OPEN"
-    },
-    {
-      "repo": "aerospike-py",
-      "number": 374,
-      "title": "feat!: LazyBatchRecords handle + GIL-detach to_numpy(dtype)",
-      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/374",
-      "author": "KimSoungRyoul",
-      "createdAt": "2026-05-23T16:43:36Z",
-      "state": "MERGED"
-    },
-    {
-      "repo": "aerospike-cluster-manager",
-      "number": 392,
-      "title": "fix: extend bin-name validation to remaining models and UI dialogs",
-      "url": "https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/392",
-      "author": "KimSoungRyoul",
-      "createdAt": "2026-05-23T02:29:35Z",
       "state": "MERGED"
     }
   ]

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -8,7 +8,7 @@ import styles from './index.module.css';
 const repos = [
   {
     name: 'aerospike-py',
-    description: 'Rust(PyO3) 기반 고성능 Python 클라이언트',
+    description: 'High-performance Python client backed by Rust (PyO3)',
     tech: 'Python / Rust',
     docs: 'https://aerospike-ce-ecosystem.github.io/aerospike-py/',
     github: 'https://github.com/aerospike-ce-ecosystem/aerospike-py',
@@ -22,21 +22,21 @@ const repos = [
   },
   {
     name: 'Cluster Manager',
-    description: '웹 기반 클러스터 관리 UI',
+    description: 'Web UI for managing CE clusters',
     tech: 'Next.js / FastAPI',
     docs: null,
     github: 'https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager',
   },
   {
     name: 'ackoctl',
-    description: 'cluster-manager CLI · Aerospike 운영 자동화',
+    description: 'CLI for cluster-manager and day-2 Aerospike operations',
     tech: 'Go / cobra',
     docs: null,
     github: 'https://github.com/aerospike-ce-ecosystem/ackoctl',
   },
   {
     name: 'Plugins',
-    description: 'Claude Code 에코시스템 플러그인 (9 skills)',
+    description: 'Claude Code plugin pack for the ecosystem (9 skills)',
     tech: 'Claude Code',
     docs: null,
     github: 'https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins',
@@ -52,7 +52,7 @@ function HomepageHeader() {
         <h1 className={styles.heroTitle}>{siteConfig.title}</h1>
         <p className={styles.heroSubtitle}>{siteConfig.tagline}</p>
         <p className={styles.heroLead}>
-          Aerospike CE를 위한 모던 Python 클라이언트 · Kubernetes Operator · 웹 UI · CLI · AI 개발 도구를 한 곳에서.
+          A modern Python client, Kubernetes operator, web UI, CLI, and AI development tooling for Aerospike CE — all in one place.
         </p>
         <div className={styles.heroCtas}>
           <Link className="button button--primary button--lg" to="/docs/intro">
@@ -97,15 +97,15 @@ export default function Home(): React.JSX.Element {
   return (
     <Layout
       title="Aerospike CE Ecosystem Hub"
-      description="Aerospike CE 생태계 — Python 클라이언트, Kubernetes Operator, Cluster Manager, ackoctl, Plugins를 위한 단일 허브"
+      description="The Aerospike CE ecosystem — one hub for the Python client, Kubernetes operator, cluster manager, ackoctl, and plugins."
     >
       <HomepageHeader />
       <main className={styles.mainWrap}>
         <section className={clsx('container', styles.section)}>
           <div className={styles.sectionHead}>
-            <h2>Core Repositories</h2>
+            <h2>Core repositories</h2>
             <p className={styles.sectionDesc}>
-              생태계를 구성하는 핵심 리포지토리. 각 프로젝트는 독립적으로 사용할 수 있도록 느슨하게 결합되어 있습니다.
+              The repositories that make up the ecosystem. Each project is loosely coupled so it can be adopted on its own.
             </p>
           </div>
           <div className="row">

--- a/scripts/collect-pr-stats.mjs
+++ b/scripts/collect-pr-stats.mjs
@@ -90,24 +90,30 @@ function isoWeekEnd(label) {
   return end;
 }
 
+const MONTH_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
 /**
- * "5월 1주차" — Thursday-of-week determines which month the week belongs to,
+ * "May W1" — Thursday-of-week determines which month the week belongs to,
  * matching the ISO 8601 convention used to assign weeks to years. For a week
  * that straddles a month boundary, the side with 4+ days wins (Mon–Thu rule).
  */
-function koreanWeekLabel(isoLabel) {
+function weekDisplayLabel(isoLabel) {
   const monday = isoWeekStart(isoLabel);
   const thu = new Date(monday);
   thu.setUTCDate(monday.getUTCDate() + 3);
   const weekInMonth = Math.floor((thu.getUTCDate() - 1) / 7) + 1;
-  return `${thu.getUTCMonth() + 1}월 ${weekInMonth}주차`;
+  return `${MONTH_SHORT[thu.getUTCMonth()]} W${weekInMonth}`;
 }
 
 function dateRangeLabel(isoLabel) {
   const s = isoWeekStart(isoLabel);
   const e = isoWeekEnd(isoLabel);
   const pad = (n) => String(n).padStart(2, '0');
-  return `${s.getUTCMonth() + 1}/${pad(s.getUTCDate())}–${e.getUTCMonth() + 1}/${pad(e.getUTCDate())}`;
+  // e.g. "May 18–24" (same month) or "Apr 27 – May 03" (cross-month)
+  if (s.getUTCMonth() === e.getUTCMonth()) {
+    return `${MONTH_SHORT[s.getUTCMonth()]} ${pad(s.getUTCDate())}–${pad(e.getUTCDate())}`;
+  }
+  return `${MONTH_SHORT[s.getUTCMonth()]} ${pad(s.getUTCDate())} – ${MONTH_SHORT[e.getUTCMonth()]} ${pad(e.getUTCDate())}`;
 }
 
 async function gh(args) {
@@ -294,13 +300,13 @@ async function main() {
     repos: activeRepos,
     perRepoTotal,
     weeksAxis,
-    weeksKorean: weeksAxis.map(koreanWeekLabel),
+    weeksDisplay: weeksAxis.map(weekDisplayLabel),
     weeksDateRange: weeksAxis.map(dateRangeLabel),
     repoSeries,
     totalPerWeek,
     recent4Weeks: recent4,
     recent4Total,
-    peakWeek: peakWeek ? {week: peakWeek, korean: koreanWeekLabel(peakWeek), count: peakCount} : null,
+    peakWeek: peakWeek ? {week: peakWeek, display: weekDisplayLabel(peakWeek), count: peakCount} : null,
     avgPerWeek: weeksAxis.length ? Number((totalPrs / weeksAxis.length).toFixed(2)) : 0,
     stateCounts: Object.fromEntries(stateCounter),
     topContributors,
@@ -312,7 +318,7 @@ async function main() {
   await writeFile(OUT_PATH, JSON.stringify(out, null, 2) + '\n');
   console.error(`\nWrote ${OUT_PATH}`);
   console.error(`  ${totalPrs} PRs across ${weeksAxis.length} weeks (${activeRepos.length} active repos)`);
-  console.error(`  peak: ${out.peakWeek?.korean} (${peakCount})  avg/week: ${out.avgPerWeek}`);
+  console.error(`  peak: ${out.peakWeek?.display} (${peakCount})  avg/week: ${out.avgPerWeek}`);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

Follow-up to #104. The initial home-page stats panel landed with Korean copy because the rest of the page was already in Korean. The workspace convention (per the top-level `CLAUDE.md`) is English for all documentation, so we are aligning here.

## What changed

- **HomeStats**: KPI labels, section headings, tooltips, aria-labels, contributor copy, recent-PRs caption.
- **Home page**: hero lead, section description, the four pre-existing repo card descriptions, and the new ackoctl card.
- **Workflow**: `weekly-pr-stats.yml` — `workflow_dispatch` input description and the body of the auto-PR template.
- **Week label format**: `koreanWeekLabel` (`5월 1주차`) → `weekDisplayLabel` (`May W1`). Date range uses abbreviated months (`May 18–24`, or `Apr 27 – May 03` when the week crosses a month boundary).
- **JSON schema**: `weeksKorean` → `weeksDisplay`, `peakWeek.korean` → `peakWeek.display`. TypeScript types + all consumers updated.

## Schema break

`pr-stats.json` shape changes — the previously auto-generated PR #105 was using the old fields and was closed to avoid merging stale data against the new types. The next workflow run after this lands will open a fresh refresh PR with the new schema.

## Test plan

- [x] `npm run typecheck` (docs/)
- [x] `npm run build` (docs/) — no new warnings
- [x] `grep -r "[가-힣]"` over the touched paths returns empty
- [x] Local `node scripts/collect-pr-stats.mjs` produced 990 PRs / 17 weeks / 8 repos with the new label format (peak: `May W3 (110)`)