### PR TITLE
chore(ci): bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -23,15 +23,15 @@ jobs:
       run:
         working-directory: docs
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: docs/package-lock.json
       - run: npm ci
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/build
 
@@ -44,4 +44,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,8 +12,8 @@ jobs:
       run:
         working-directory: docs
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/weekly-pr-stats.yml
+++ b/.github/workflows/weekly-pr-stats.yml
@@ -26,12 +26,12 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
 
@@ -77,8 +77,8 @@ jobs:
           steps.changes.outputs.changed == 'true' &&
           (github.event_name == 'schedule' || inputs.open_pr != false)
         # Pinned to a commit SHA per OpenSSF Scorecard guidance.
-        # SHA = peter-evans/create-pull-request v7 head (2025-12-05).
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        # SHA = peter-evans/create-pull-request v8.1.1.
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: bot/weekly-pr-stats


### PR DESCRIPTION
## Summary
- actions/checkout: v4 → v6 (docs.yaml, docs-publish.yaml); SHA pin updated to v6.0.2 in weekly-pr-stats.yml
- actions/setup-node: v4 → v6 (docs.yaml, docs-publish.yaml); SHA pin updated to v6.4.0 in weekly-pr-stats.yml
- actions/upload-pages-artifact: v3 → v5 (docs-publish.yaml)
- actions/deploy-pages: v4 → v5 (docs-publish.yaml)
- peter-evans/create-pull-request: SHA pin updated from v7 to v8.1.1 in weekly-pr-stats.yml

SHA pins for security-sensitive `weekly-pr-stats.yml` were retained per OpenSSF Scorecard guidance — only the pinned SHA values were updated. Latest versions confirmed via GitHub API.

## Test plan
- [x] docs build job runs on docs/** PRs (this PR doesn't touch docs/, so the workflow won't fire here; will validate on next docs PR)
- [ ] docs-publish only fires on push to main with docs/** changes
- [ ] weekly-pr-stats fires on cron / manual dispatch