### PR TITLE
docs(home): add motivation section, link cross-repo docs, tighten cards

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -57,7 +57,17 @@ const config: Config = {
           type: 'docSidebar',
           sidebarId: 'docsSidebar',
           position: 'left',
-          label: 'Docs',
+          label: 'Docs (Project Hub)',
+        },
+        {
+          href: 'https://aerospike-ce-ecosystem.github.io/aerospike-py/',
+          label: 'aerospike-py',
+          position: 'left',
+        },
+        {
+          href: 'https://aerospike-ce-ecosystem.github.io/aerospike-ce-kubernetes-operator/',
+          label: 'ACKO',
+          position: 'left',
         },
         {
           href: 'https://github.com/aerospike-ce-ecosystem',

--- a/docs/src/components/WhySection/index.tsx
+++ b/docs/src/components/WhySection/index.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+interface Problem {
+  tag: string;
+  title: string;
+  problem: React.ReactNode;
+  solution: React.ReactNode;
+}
+
+const PROBLEMS: Problem[] = [
+  {
+    tag: '01 · Performance',
+    title: 'The Python client cannot carry an ML feature-store workload',
+    problem: (
+      <>
+        Aerospike is a natural fit for online feature stores — sub-millisecond
+        point reads, predictable tail latency, native list/map types for
+        feature vectors. But Python is the working language of ML pipelines,
+        and the official client wraps the C library through CFFI:
+        the GIL is held across the I/O path, async support is bolted on,
+        and the type stubs drift from the runtime. At feature-store
+        throughput, that gap is large enough to disqualify Aerospike from
+        otherwise good-fit use cases.
+      </>
+    ),
+    solution: (
+      <>
+        →&nbsp;<code>aerospike-py</code> — a from-scratch client in
+        Rust&nbsp;(PyO3) with native async, GIL release across the I/O path,
+        NumPy batch fast-paths, and complete type stubs. About <strong>2.4×
+        the throughput</strong> of the official C client on standard mixed
+        workloads, with first-class support for ML inference servers.
+      </>
+    ),
+  },
+  {
+    tag: '02 · Cloud-native',
+    title: 'No CE-grade Kubernetes story',
+    problem: (
+      <>
+        Aerospike CE ships no community Kubernetes operator — the upstream
+        AKO is Enterprise-only. There is no maintained web management UI,
+        and most operational tooling assumes bare-metal deployments.
+        Day-2 operations on Kubernetes (scaling, rolling upgrades, warm
+        restarts, dynamic config) are left to teams to reinvent.
+      </>
+    ),
+    solution: (
+      <>
+        →&nbsp;<strong>ACKO</strong> (CE-focused operator)
+        +&nbsp;<strong>Cluster Manager</strong> (FastAPI + Next.js UI)
+        +&nbsp;<code>ackoctl</code> (CLI). Declarative cluster management,
+        scaling and rolling upgrades, warm-restart workflows, ACL
+        management, OpenTelemetry-instrumented data path — all driven by
+        CRDs and exposed through a UI and a CLI.
+      </>
+    ),
+  },
+  {
+    tag: '03 · EE gate',
+    title: 'Enterprise Edition is often out of reach inside large orgs',
+    problem: (
+      <>
+        Adopting Aerospike EE requires an org-level contract. Inside a
+        large organization, procurement, legal, finance, and architecture
+        sign-offs become their own blocker — a classic <em>bell the
+        cat</em> problem where everyone agrees EE would help, but no one
+        owns pushing the contract through, and the cost-justification
+        burden lands on whoever raises their hand.
+      </>
+    ),
+    solution: (
+      <>
+        →&nbsp;Every component supports <strong>both CE and EE</strong>.
+        Teams ship on CE today, with the same operator, the same client,
+        the same observability surface — and transparently move to EE
+        later if and when the contract lands. The ecosystem unblocks
+        adoption without forcing the contract decision up front.
+      </>
+    ),
+  },
+];
+
+const COMMITMENTS: {title: string; body: React.ReactNode}[] = [
+  {
+    title: 'Open-source first, EE-compatible',
+    body: (
+      <>
+        Every component runs against both Aerospike CE and EE, so adoption
+        is not gated on procurement. CE today, EE later, no integration
+        rewrite.
+      </>
+    ),
+  },
+  {
+    title: 'Cloud-native by default',
+    body: (
+      <>
+        Declarative Kubernetes management via ACKO, a real web UI for cluster
+        ops, and an OpenTelemetry-instrumented data path — without an EE
+        license.
+      </>
+    ),
+  },
+  {
+    title: 'Agent-driven operations',
+    body: (
+      <>
+        The same operational primitives are exposed through{' '}
+        <code>ackoctl</code> and a Claude Code plugin pack. Agents can
+        provision, scale, debug, and operate Aerospike clusters with the
+        same surface a human operator uses.
+      </>
+    ),
+  },
+];
+
+export default function WhySection(): React.JSX.Element {
+  return (
+    <section className={clsx('container', styles.section)}>
+      <div className={styles.intro}>
+        <span className={styles.eyebrow}>Why this ecosystem exists</span>
+        <h2 className={styles.title}>
+          Aerospike is fast. Adopting it well, less so.
+        </h2>
+        <p className={styles.lead}>
+          Aerospike is a high-performance, low-latency NoSQL database, and an
+          excellent fit for online feature stores and other low-latency
+          serving paths. Three practical gaps make it hard to actually ship
+          on Aerospike at production quality today — especially inside large
+          organizations and on Kubernetes. The <strong>aerospike-ce-ecosystem</strong> closes
+          those gaps with an open-source, cloud-native, agent-friendly toolchain.
+        </p>
+      </div>
+
+      <div className={clsx('row', styles.problemRow)}>
+        {PROBLEMS.map((p) => (
+          <div key={p.tag} className={clsx('col col--4', styles.problemCol)}>
+            <article className={styles.problemCard}>
+              <div className={styles.problemTag}>{p.tag}</div>
+              <h3 className={styles.problemTitle}>{p.title}</h3>
+              <p className={styles.problemBody}>{p.problem}</p>
+              <p className={styles.problemSolution}>{p.solution}</p>
+            </article>
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.commitmentsBlock}>
+        <h3 className={styles.commitmentsTitle}>What we ship</h3>
+        <ul className={styles.commitmentsList}>
+          {COMMITMENTS.map((c) => (
+            <li key={c.title}>
+              <strong>{c.title}.</strong> {c.body}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/docs/src/components/WhySection/styles.module.css
+++ b/docs/src/components/WhySection/styles.module.css
@@ -1,0 +1,159 @@
+.section {
+  padding: 3.5rem 0 1rem;
+}
+
+/* ── Intro ───────────────────────────────────────────────────── */
+.intro {
+  max-width: 760px;
+  margin-bottom: 2.25rem;
+}
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ifm-color-primary) 10%, transparent);
+  color: var(--ifm-color-primary);
+  font-size: 11.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.eyebrow::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ifm-color-primary);
+}
+.title {
+  margin: 12px 0 8px;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  color: var(--ifm-color-content);
+}
+.lead {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--ifm-color-emphasis-700);
+}
+
+/* ── Problem grid ────────────────────────────────────────────── */
+.problemRow {
+  align-items: stretch;
+}
+.problemCol {
+  margin-bottom: 1rem;
+}
+.problemCard {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 22px 22px 20px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 14px;
+  background: var(--ifm-card-background-color);
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+.problemCard:hover {
+  border-color: var(--ifm-color-primary);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px color-mix(in srgb, var(--ifm-color-primary) 12%, transparent);
+}
+.problemTag {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 8px;
+}
+.problemTitle {
+  margin: 0 0 12px;
+  font-size: 1.075rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.35;
+  color: var(--ifm-color-content);
+}
+.problemBody {
+  margin: 0 0 14px;
+  font-size: 13.5px;
+  line-height: 1.65;
+  color: var(--ifm-color-emphasis-700);
+  flex-grow: 1;
+}
+.problemSolution {
+  margin: 0;
+  padding: 12px 14px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--ifm-color-content);
+  background: color-mix(in srgb, var(--ifm-color-primary) 6%, transparent);
+  border-left: 3px solid var(--ifm-color-primary);
+  border-radius: 0 8px 8px 0;
+}
+.problemSolution code {
+  padding: 1px 6px;
+  font-size: 11.5px;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 4px;
+}
+.problemBody code {
+  padding: 1px 5px;
+  font-size: 12px;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 4px;
+}
+
+/* ── Commitments block ──────────────────────────────────────── */
+.commitmentsBlock {
+  margin-top: 2.5rem;
+  padding: 24px 26px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 14px;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--ifm-color-primary) 4%, transparent) 0%,
+    transparent 100%
+  );
+}
+.commitmentsTitle {
+  margin: 0 0 14px;
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--ifm-color-content);
+}
+.commitmentsList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+@media (max-width: 880px) {
+  .commitmentsList {
+    grid-template-columns: 1fr;
+  }
+}
+.commitmentsList li {
+  font-size: 13.5px;
+  line-height: 1.65;
+  color: var(--ifm-color-emphasis-700);
+}
+.commitmentsList li strong {
+  color: var(--ifm-color-content);
+}
+.commitmentsList li code {
+  padding: 1px 6px;
+  font-size: 11.5px;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 4px;
+}

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -93,17 +93,10 @@
   box-shadow: 0 6px 20px color-mix(in srgb, var(--ifm-color-primary) 12%, transparent);
 }
 .repoName {
-  margin: 0 0 4px;
+  margin: 0;
   font-size: 1.15rem;
   font-weight: 700;
   letter-spacing: -0.01em;
-}
-.repoTech {
-  margin: 0;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--ifm-color-primary);
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
 }
 .repoDesc {
   margin: 0;

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -3,41 +3,42 @@ import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import HomeStats from '@site/src/components/HomeStats';
+import WhySection from '@site/src/components/WhySection';
 import styles from './index.module.css';
 
 const repos = [
   {
     name: 'aerospike-py',
-    description: 'High-performance Python client backed by Rust (PyO3)',
-    tech: 'Python / Rust',
+    description:
+      'High-performance Python client built on Rust (PyO3). Native async, GIL release across the I/O path, NumPy batch fast-paths — designed for ML feature-store and inference-serving workloads.',
     docs: 'https://aerospike-ce-ecosystem.github.io/aerospike-py/',
     github: 'https://github.com/aerospike-ce-ecosystem/aerospike-py',
   },
   {
     name: 'ACKO',
-    description: 'Aerospike CE Kubernetes Operator',
-    tech: 'Go / Kubebuilder',
+    description:
+      'CE-focused Kubernetes operator. Declarative cluster management, rolling upgrades, warm restarts, ACL sync, OpenTelemetry-instrumented data path.',
     docs: 'https://aerospike-ce-ecosystem.github.io/aerospike-ce-kubernetes-operator/',
     github: 'https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator',
   },
   {
     name: 'Cluster Manager',
-    description: 'Web UI for managing CE clusters',
-    tech: 'Next.js / FastAPI',
+    description:
+      'Web UI for cluster operations — namespace browsing, record inspection, query builder, and Kubernetes cluster management on top of ACKO.',
     docs: null,
     github: 'https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager',
   },
   {
     name: 'ackoctl',
-    description: 'CLI for cluster-manager and day-2 Aerospike operations',
-    tech: 'Go / cobra',
+    description:
+      'CLI surface for cluster-manager and ACKO. The same operational primitives the UI exposes, scriptable from terminals and agents.',
     docs: null,
     github: 'https://github.com/aerospike-ce-ecosystem/ackoctl',
   },
   {
     name: 'Plugins',
-    description: 'Claude Code plugin pack for the ecosystem (9 skills)',
-    tech: 'Claude Code',
+    description:
+      'Claude Code plugin pack — nine skills covering deployment, debugging, day-2 operations, e2e testing, and bug routing for the ecosystem.',
     docs: null,
     github: 'https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins',
   },
@@ -67,13 +68,12 @@ function HomepageHeader() {
   );
 }
 
-function RepoCard({name, description, tech, docs, github}: (typeof repos)[0]) {
+function RepoCard({name, description, docs, github}: (typeof repos)[0]) {
   return (
     <div className={clsx('col col--4', styles.repoCol)}>
       <div className={clsx('card', styles.repoCard)}>
         <div className="card__header">
           <h3 className={styles.repoName}>{name}</h3>
-          <p className={styles.repoTech}>{tech}</p>
         </div>
         <div className="card__body">
           <p className={styles.repoDesc}>{description}</p>
@@ -101,6 +101,8 @@ export default function Home(): React.JSX.Element {
     >
       <HomepageHeader />
       <main className={styles.mainWrap}>
+        <WhySection />
+
         <section className={clsx('container', styles.section)}>
           <div className={styles.sectionHead}>
             <h2>Core repositories</h2>


### PR DESCRIPTION
## Summary

The home page now opens with **why this ecosystem exists** before listing what it contains. Plus a navbar refresh so the cross-repo doc sites are reachable in one click, and a clean-up of the repo cards.

## What changed

### New `WhySection` between hero and Core repositories

Three problem → solution cards walk through the gaps the ecosystem closes:

| # | Problem | What we ship for it |
|---|---------|---------------------|
| 01 · Performance | The official Python client cannot carry an ML feature-store workload — CFFI wrapping, GIL held across the I/O path, async bolted on, drifted type stubs. | `aerospike-py` — Rust/PyO3 rewrite. Native async, GIL release across I/O, NumPy batch fast-paths, ~2.4× the throughput of the C client on mixed workloads. |
| 02 · Cloud-native | CE ships no community Kubernetes operator (upstream AKO is EE-only), no maintained web UI, and tooling assumes bare metal. | **ACKO** + **Cluster Manager** + `ackoctl`. Declarative cluster mgmt, rolling upgrades, warm restarts, ACL sync, OpenTelemetry data path. |
| 03 · EE gate | Adopting EE requires an org-level contract. In large orgs the procurement / legal / finance / architecture sign-off chain becomes its own blocker — a classic *bell-the-cat* problem. | Every component supports **both CE and EE**. Ship on CE today, move to EE later without rewriting integrations or operational tooling. |

Followed by a *"What we ship"* block summarising the three commitments — **open-source first**, **cloud-native by default**, **agent-driven operations**.

### Navbar

- Rename `Docs` → `Docs (Project Hub)` so it's clear which doc surface this is.
- Add direct links to the `aerospike-py` and `ACKO` published doc sites so readers can move across repos without bouncing through GitHub.

### Repo cards

- Drop the freeform `tech:` line (`Python / Rust`, `Next.js / FastAPI`, ...) — it was noise rather than information.
- Rewrite each card description to state what the project actually delivers, not just its stack.

## Test plan

- [x] `npm run typecheck` (docs/)
- [x] `npm run build` (docs/) — no new warnings
- [x] Visual check: WhySection renders on both light and dark theme; problem cards stack on narrow viewports
- [x] Navbar external links open the upstream doc sites