### PR TITLE
docs(home): regroup Core repositories into three layers, show ACKO containment

### DIFF
--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -77,8 +77,91 @@
   line-height: 1.6;
 }
 
+/* Repo groups ─────────────────────────────────────── */
+.group {
+  margin-bottom: 1.75rem;
+}
+.groupHead {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+.groupLabel {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.groupNote {
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--ifm-color-emphasis-700);
+  max-width: 740px;
+}
+.groupNote code {
+  padding: 1px 6px;
+  font-size: 11.5px;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 4px;
+}
+
+/* Standalone (1-N siblings) ──────────────────────── */
+.standaloneGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+/* ACKO stack — visual containment block ──────────── */
+.ackoStack {
+  position: relative;
+  padding: 22px 22px 20px;
+  border: 1px dashed var(--ifm-color-primary);
+  border-radius: 16px;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--ifm-color-primary) 4%, transparent) 0%,
+    color-mix(in srgb, var(--ifm-color-primary) 1%, transparent) 100%
+  );
+}
+.ackoStack .groupHead {
+  margin-bottom: 16px;
+}
+.ackoParentWrap {
+  margin-bottom: 0;
+}
+.ackoConnector {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 0 12px;
+  color: var(--ifm-color-primary);
+}
+.ackoConnectorLine {
+  flex: 1;
+  height: 1px;
+  background: color-mix(in srgb, var(--ifm-color-primary) 30%, transparent);
+}
+.ackoConnectorLabel {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ifm-color-primary) 12%, transparent);
+}
+.ackoChildrenGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+}
+
 /* Repo cards ──────────────────────────────────────── */
-.repoCol { margin-bottom: 1rem; }
 .repoCard {
   height: 100%;
   display: flex;
@@ -92,17 +175,31 @@
   border-color: var(--ifm-color-primary);
   box-shadow: 0 6px 20px color-mix(in srgb, var(--ifm-color-primary) 12%, transparent);
 }
+.repoCardParent {
+  border-width: 2px;
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--ifm-color-primary) 10%, transparent);
+}
+.repoCardChild {
+  background: var(--ifm-card-background-color);
+}
 .repoName {
   margin: 0;
   font-size: 1.15rem;
   font-weight: 700;
   letter-spacing: -0.01em;
 }
+.repoCardChild .repoName {
+  font-size: 1.05rem;
+}
 .repoDesc {
   margin: 0;
   font-size: 14px;
   line-height: 1.55;
   color: var(--ifm-color-content-secondary);
+}
+.repoCardChild .repoDesc {
+  font-size: 13.5px;
 }
 .repoFooter {
   display: flex;

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,43 +6,52 @@ import HomeStats from '@site/src/components/HomeStats';
 import WhySection from '@site/src/components/WhySection';
 import styles from './index.module.css';
 
-const repos = [
-  {
-    name: 'aerospike-py',
-    description:
-      'High-performance Python client built on Rust (PyO3). Native async, GIL release across the I/O path, NumPy batch fast-paths — designed for ML feature-store and inference-serving workloads.',
-    docs: 'https://aerospike-ce-ecosystem.github.io/aerospike-py/',
-    github: 'https://github.com/aerospike-ce-ecosystem/aerospike-py',
-  },
-  {
-    name: 'ACKO',
-    description:
-      'CE-focused Kubernetes operator. Declarative cluster management, rolling upgrades, warm restarts, ACL sync, OpenTelemetry-instrumented data path.',
-    docs: 'https://aerospike-ce-ecosystem.github.io/aerospike-ce-kubernetes-operator/',
-    github: 'https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator',
-  },
-  {
-    name: 'Cluster Manager',
-    description:
-      'Web UI for cluster operations — namespace browsing, record inspection, query builder, and Kubernetes cluster management on top of ACKO.',
-    docs: null,
-    github: 'https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager',
-  },
-  {
-    name: 'ackoctl',
-    description:
-      'CLI surface for cluster-manager and ACKO. The same operational primitives the UI exposes, scriptable from terminals and agents.',
-    docs: null,
-    github: 'https://github.com/aerospike-ce-ecosystem/ackoctl',
-  },
-  {
-    name: 'Plugins',
-    description:
-      'Claude Code plugin pack — nine skills covering deployment, debugging, day-2 operations, e2e testing, and bug routing for the ecosystem.',
-    docs: null,
-    github: 'https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins',
-  },
-];
+interface Repo {
+  name: string;
+  description: string;
+  docs: string | null;
+  github: string;
+}
+
+const aerospikePy: Repo = {
+  name: 'aerospike-py',
+  description:
+    'High-performance Python client built on Rust (PyO3). Native async, GIL release across the I/O path, NumPy batch fast-paths — designed for ML feature-store and inference-serving workloads.',
+  docs: 'https://aerospike-ce-ecosystem.github.io/aerospike-py/',
+  github: 'https://github.com/aerospike-ce-ecosystem/aerospike-py',
+};
+
+const acko: Repo = {
+  name: 'ACKO',
+  description:
+    'CE-focused Kubernetes operator. Declarative cluster management, rolling upgrades, warm restarts, ACL sync, OpenTelemetry-instrumented data path.',
+  docs: 'https://aerospike-ce-ecosystem.github.io/aerospike-ce-kubernetes-operator/',
+  github: 'https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator',
+};
+
+const clusterManager: Repo = {
+  name: 'Cluster Manager',
+  description:
+    'Web UI for cluster operations — namespace browsing, record inspection, query builder, and K8s cluster management. Deployed by ACKO as part of the stack.',
+  docs: null,
+  github: 'https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager',
+};
+
+const ackoctl: Repo = {
+  name: 'ackoctl',
+  description:
+    'CLI surface for cluster-manager and ACKO. The same operational primitives the UI exposes, scriptable from terminals and agents.',
+  docs: null,
+  github: 'https://github.com/aerospike-ce-ecosystem/ackoctl',
+};
+
+const plugins: Repo = {
+  name: 'Plugins',
+  description:
+    'Claude Code plugin pack — nine skills covering deployment, debugging, day-2 operations, e2e testing, and bug routing across the ecosystem.',
+  docs: null,
+  github: 'https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins',
+};
 
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
@@ -68,26 +77,79 @@ function HomepageHeader() {
   );
 }
 
-function RepoCard({name, description, docs, github}: (typeof repos)[0]) {
+function RepoCard({repo, variant = 'default'}: {repo: Repo; variant?: 'default' | 'parent' | 'child'}) {
+  const cardClass = clsx(
+    'card',
+    styles.repoCard,
+    variant === 'parent' && styles.repoCardParent,
+    variant === 'child' && styles.repoCardChild,
+  );
   return (
-    <div className={clsx('col col--4', styles.repoCol)}>
-      <div className={clsx('card', styles.repoCard)}>
-        <div className="card__header">
-          <h3 className={styles.repoName}>{name}</h3>
-        </div>
-        <div className="card__body">
-          <p className={styles.repoDesc}>{description}</p>
-        </div>
-        <div className={clsx('card__footer', styles.repoFooter)}>
-          <a href={github} className="button button--outline button--primary button--sm">
-            GitHub
+    <div className={cardClass}>
+      <div className="card__header">
+        <h3 className={styles.repoName}>{repo.name}</h3>
+      </div>
+      <div className="card__body">
+        <p className={styles.repoDesc}>{repo.description}</p>
+      </div>
+      <div className={clsx('card__footer', styles.repoFooter)}>
+        <a href={repo.github} className="button button--outline button--primary button--sm">
+          GitHub
+        </a>
+        {repo.docs && (
+          <a href={repo.docs} className="button button--primary button--sm">
+            Docs
           </a>
-          {docs && (
-            <a href={docs} className="button button--primary button--sm">
-              Docs
-            </a>
-          )}
-        </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StandaloneGroup({label, note, repos}: {label: string; note: string; repos: Repo[]}) {
+  return (
+    <div className={styles.group}>
+      <div className={styles.groupHead}>
+        <span className={styles.groupLabel}>{label}</span>
+        <span className={styles.groupNote}>{note}</span>
+      </div>
+      <div className={styles.standaloneGrid}>
+        {repos.map((r) => (
+          <RepoCard key={r.name} repo={r} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AckoStackGroup() {
+  return (
+    <div className={clsx(styles.group, styles.ackoStack)}>
+      <div className={styles.groupHead}>
+        <span className={styles.groupLabel}>ACKO Kubernetes stack</span>
+        <span className={styles.groupNote}>
+          Aerospike CE on Kubernetes, end-to-end. <code>cluster-manager</code> and{' '}
+          <code>ackoctl</code> ship as part of the ACKO stack — the operator
+          deploys the UI, and the CLI drives the same control plane the UI uses.
+        </span>
+      </div>
+
+      {/* Parent: ACKO */}
+      <div className={styles.ackoParentWrap}>
+        <RepoCard repo={acko} variant="parent" />
+      </div>
+
+      {/* Containment connector */}
+      <div className={styles.ackoConnector} aria-hidden>
+        <span className={styles.ackoConnectorLine} />
+        <span className={styles.ackoConnectorLabel}>contains</span>
+        <span className={styles.ackoConnectorLine} />
+      </div>
+
+      {/* Children: Cluster Manager + ackoctl */}
+      <div className={styles.ackoChildrenGrid}>
+        <RepoCard repo={clusterManager} variant="child" />
+        <RepoCard repo={ackoctl} variant="child" />
       </div>
     </div>
   );
@@ -107,14 +169,25 @@ export default function Home(): React.JSX.Element {
           <div className={styles.sectionHead}>
             <h2>Core repositories</h2>
             <p className={styles.sectionDesc}>
-              The repositories that make up the ecosystem. Each project is loosely coupled so it can be adopted on its own.
+              The ecosystem is organised into three layers — an application-side
+              client, an ACKO-driven Kubernetes stack, and an optional AI tooling
+              pack. Each layer can be adopted on its own.
             </p>
           </div>
-          <div className="row">
-            {repos.map((repo) => (
-              <RepoCard key={repo.name} {...repo} />
-            ))}
-          </div>
+
+          <StandaloneGroup
+            label="Client"
+            note="Application-side surface — embeds directly into Python services."
+            repos={[aerospikePy]}
+          />
+
+          <AckoStackGroup />
+
+          <StandaloneGroup
+            label="Developer tooling"
+            note="Optional, agent-facing — speeds up day-1 and day-2 work without changing the data plane."
+            repos={[plugins]}
+          />
         </section>
 
         <section className={clsx('container', styles.section)}>


### PR DESCRIPTION
## Summary

The flat 5-card Core repositories grid did not reflect how the projects actually relate. ACKO is the operator stack: Cluster Manager is a sub-component it deploys, and ackoctl is its CLI surface. Showing them as peers misled readers into thinking they were independent installs.

## New layout — three labelled groups

| Layer | Repos | Role |
|-------|-------|------|
| **Client** | `aerospike-py` | Application-side surface |
| **ACKO Kubernetes stack** | `ACKO` (parent) + `Cluster Manager` + `ackoctl` | Kubernetes control plane |
| **Developer tooling** | `Plugins` | Optional, agent-facing |

The ACKO group renders as one bordered container: ACKO on top with a thicker primary-color border, a *"contains"* connector below it, then a 2-column nested grid for Cluster Manager and ackoctl.

The group note spells out the relationship in words too — *"cluster-manager and ackoctl ship as part of the ACKO stack — the operator deploys the UI, and the CLI drives the same control plane the UI uses."*

## Card refactor

- `RepoCard` now takes a `variant` of `default` | `parent` | `child` for size / emphasis differences.
- Replaced the Docusaurus `col col--4` row with CSS-grid groups, so columns reflow on narrow viewports without fighting the bootstrap grid.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build` — no new warnings
- [x] Visual check: light + dark theme, narrow viewport reflow