### PR TITLE
docs(goals): make project-goals the canonical motivation doc

### DIFF
--- a/docs/docs/goals/project-goals.md
+++ b/docs/docs/goals/project-goals.md
@@ -1,89 +1,223 @@
 ---
 title: Project Goals
-description: Aerospike CE Ecosystem 각 프로젝트의 개발 방향과 제약 조건 정의
+description: Ecosystem motivation and per-project development goals for the Aerospike CE Ecosystem.
 sidebar_position: 1
 scope: ecosystem
 repos:
   - aerospike-py
   - acko
   - cluster-manager
+  - ackoctl
   - plugins
 tags:
   - goals
   - constraints
   - principles
   - development-guidelines
-last_updated: 2026-05-23
+last_updated: 2026-05-27
 ---
 
 # Project Goals
 
-Aerospike CE Ecosystem 각 프로젝트의 개발 방향과 제약 조건.
+This page is the single source of truth for **why the Aerospike CE Ecosystem
+exists** and **what each project in it is trying to accomplish**. Every
+repository in the ecosystem links back here; downstream design decisions are
+expected to align with these goals.
 
 ---
 
-## 1. aerospike-py
+## Why this ecosystem exists
 
-> Aerospike Python Rust binding async client
+Aerospike is a high-performance, low-latency NoSQL database and a natural fit
+for online feature stores and other latency-critical serving paths. Yet
+adopting Aerospike well today has three rough edges that this ecosystem was
+created to close.
 
-1-1. **고성능 유지** — Rust(PyO3) 기반의 성능 이점을 항상 유지할 것
+### 1. The official Python client cannot carry an ML feature-store workload
 
-1-2. **aerospike-client-rust v2 추적** — aerospike-client-rust v2를 Skills로 이해하고 있을 것. 최신 버전이 나오면 도입 검토할 것
+The upstream Python client wraps the C library through CFFI. The GIL is held
+across the I/O path, async support is bolted on, and the published type stubs
+drift from the runtime. For ML serving — where Python is the working
+language of the pipeline and feature-store reads must keep up with model
+inference — that gap is large enough to disqualify Aerospike from otherwise
+strong-fit use cases.
 
-1-3. **NumPy batch 연산 개선** — batch_read_numpy, batch_write_numpy 스펙이 잘 동작하도록 개선하고 유지보수할 것
+**Response:** `aerospike-py` — a from-scratch client written in Rust (PyO3).
+Native async, GIL release across the entire I/O path, NumPy batch
+fast-paths, and complete `.pyi` stubs. About **2.4× the throughput** of the
+official C client on standard mixed workloads.
 
-1-4. **Observability 유지** — logging, metrics, tracing(OpenTelemetry) 잘 개선하고 유지할 것. FastAPI에서 잘 동작하는지 sample-fastapi에서 테스트할 것
+### 2. CE has no community Kubernetes story
 
-1-5. **batch_write retry** — batch_write(..., retry=10) 옵션으로 client side에서 batch_write가 실패하지 않도록 최대한 제어할 것
+Aerospike CE ships no community Kubernetes operator — the upstream AKO is
+Enterprise-only. There is no maintained web management UI, and the
+operational tooling assumes bare-metal deployments. Day-2 work on
+Kubernetes (scaling, rolling upgrades, warm restarts, ACL sync, dynamic
+config rollout) is left to each team to reinvent.
 
----
+**Response:** **ACKO** (a CE-focused Kubernetes operator), **Cluster
+Manager** (a FastAPI + Next.js web UI for cluster operations), and
+`ackoctl` (a CLI surface for both). Declarative cluster management,
+rolling upgrades, warm restarts, ACL management, and an
+OpenTelemetry-instrumented data path — all driven by CRDs and exposed
+through both a UI and a CLI.
 
-## 2. aerospike-cluster-manager
+### 3. Enterprise Edition is often out of reach inside large organisations
 
-> 웹 기반 Aerospike 클러스터 관리 UI (FastAPI + Next.js)
+Adopting Aerospike EE requires an org-level contract. Inside a large
+organisation, the procurement, legal, finance, and architecture sign-off
+chain becomes its own blocker — a classic *bell-the-cat* problem where
+everyone agrees EE would help, but nobody owns pushing the contract
+through, and the cost-justification burden lands on whoever raises their
+hand first. Many teams that should be on Aerospike never get past that
+gate.
 
-2-1. **Frontend UI 컴포넌트 활용성 유지** — 공통 컴포넌트 재사용성을 잘 관리할 것
-
-2-2. **Backend read/write timeout·limit 관리** — data table 조회 시 limit 제어, 성능 문제 잘 제어할 것
-
-2-3. **ACKO UI 클러스터 관리** — ACKO 연동 K8s 클러스터 관리를 잘 제어할 것. 편의성 UX 개선
-
-2-4. **큰 틀의 UI 변경 금지** — 전체 레이아웃과 네비게이션 구조를 함부로 변경하지 말 것
-
-2-5. **ACKO 클러스터 생성 편의성** — Wizard 기반 생성 흐름의 편의성 중요
-
-2-6. **ACKO 클러스터 관리·조회·변경** — 편의성과 성능 문제 모두 중요
-
-2-7. **Backend ↔ Frontend 타입 동기화** — Backend Pydantic models와 Frontend TypeScript types(lib/api/types.ts)는 수동 동기화 필수. 모델 변경 시 양쪽 모두 업데이트할 것
-
-2-8. **Record 브라우저 대용량 데이터 성능** — scan/query 시 limit, pagination, timeout을 적절히 제어하여 대용량 데이터셋에서도 안정적으로 동작할 것
-
----
-
-## 3. ACKO (Aerospike CE Kubernetes Operator)
-
-> Kubernetes Operator for Aerospike CE cluster lifecycle management
-
-3-1. **심플한 CRD 구조 유지** — Pod, StatefulSet, Service, PVC 등 K8s 표준 리소스로 제어 가능하게 할 것. Custom Resource를 함부로 추가하지 말 것
-
-3-2. **Cluster Template 목적 유지 및 고도화**
-  - minimal: 개발용
-  - soft-rack: Stage 환경 (1 Node N Pod)
-  - hard-rack: Prod 환경 (N Node N Pod)
-  - 이 목적을 유지하면서 잘 개선하고 고도화할 것
-
-3-3. **Helm chart 버전 관리** — charts/aerospike-ce-kubernetes-operator/의 Helm chart 버전 관리와 릴리스 프로세스를 체계적으로 유지할 것
-
-3-4. **E2E 테스트 커버리지 확장** — Kind 기반 E2E 테스트 시나리오를 확장할 것 (scale, rolling update, ACL, monitoring 등 운영 시나리오)
-
-3-5. **CE 제약 Webhook 검증 신뢰성** — size≤8, namespaces≤2, no XDR/TLS 등 CE 제약 조건 검증을 항상 정확하게 유지할 것. Enterprise 기능 사용 시도 시 명확한 에러 메시지 제공
+**Response:** Every component in this ecosystem supports both Aerospike CE
+and EE. Teams ship on CE today with the same operator, the same client,
+and the same observability surface — and transparently move to EE later
+if and when the contract lands. The ecosystem unblocks adoption without
+forcing the EE decision up front.
 
 ---
 
-## 4. aerospike-ce-ecosystem-plugins
+## Ecosystem-wide commitments
 
-> Claude Code 플러그인 — AI 어시스턴트 연동
+Three commitments cut across every project in the ecosystem and override
+project-local preferences when they conflict.
 
-4-1. **Skills 최신 반영** — 각 프로젝트의 API/기능 변경 사항을 Skills에 빠르게 반영할 것 (aerospike-py API 변경, ACKO CRD 변경 등)
+### Open-source first, EE-compatible
 
-4-2. **디버깅 Skill 정확도** — ACKO 클러스터 디버깅 Skill(acko-debugging)이 실제 트러블슈팅에 유효하도록 정확도를 유지할 것
+Every component runs against both Aerospike CE and EE. Integrations, the
+operator, observability hooks, and operational tooling work identically on
+either edition. Adoption is never gated on procurement: CE today, EE later,
+no integration rewrite required.
+
+### Cloud-native by default
+
+Kubernetes is a first-class deployment target, not an afterthought.
+Declarative cluster management lives in ACKO (CRDs + reconciliation),
+day-2 operations are exposed through a web UI (Cluster Manager) and a CLI
+(`ackoctl`), and the data path is OpenTelemetry-instrumented end to end.
+None of it requires an Enterprise licence.
+
+### Agent-driven operations
+
+The same operational primitives that humans use through the UI and the CLI
+are exposed to autonomous agents. `ackoctl` produces structured output
+suitable for parsing, the Claude Code plugin pack ships nine skills covering
+deployment, debugging, day-2 ops, and e2e testing, and the project
+documentation is structured so agents can navigate the surface area without
+human translation.
+
+---
+
+## Per-project goals
+
+### 1. `aerospike-py` — Rust-backed Python client
+
+Detailed goals and reference docs live under
+`.claude/skills/project-goals/` in the repository itself; the summary is
+restated here so external readers can follow the contract.
+
+1. **Hold the performance gap.** Maintain the throughput and latency
+   advantage over the upstream C client. The Rust (PyO3) layer always
+   does the heavy lifting; Python is a thin wrapper.
+2. **Track `aerospike-client-rust` v2.** Stay current with the upstream
+   Rust crate as it evolves; pick up new features behind opt-in flags
+   when they land.
+3. **NumPy batch surface.** `batch_read_numpy` and `batch_write_numpy`
+   keep working at production quality for ML feature-store workloads.
+4. **First-class observability.** Logging, Prometheus metrics, and
+   OpenTelemetry tracing are kept current. The FastAPI integration is
+   verified end-to-end against the `sample-fastapi` example.
+5. **Client-side reliability under load.** `batch_write(..., retry=10)`
+   and related options shield callers from transient cluster issues
+   without leaking partial state.
+6. **Type safety.** Public API returns `NamedTuple`s, policies are
+   `TypedDict`s, and `.pyi` stubs are complete and aligned with the
+   runtime.
+
+### 2. ACKO — Aerospike CE Kubernetes Operator
+
+Operator for Aerospike CE cluster lifecycle on Kubernetes.
+
+1. **Minimal CRD surface.** Cluster state is expressed through Pod,
+   StatefulSet, Service, and PVC — standard Kubernetes resources first,
+   custom resources only when there is no equivalent. Resist adding
+   CRDs that users would not have asked for.
+2. **Cluster templates with sharp purposes.** Three templates with
+   distinct intent:
+   - `minimal` — single-node, for development.
+   - `soft-rack` — 1 node, N pods, for staging.
+   - `hard-rack` — N nodes, N pods, for production.
+   Improvements stay within those purposes.
+3. **Helm chart hygiene.** `charts/aerospike-ce-kubernetes-operator/` has
+   a clear release pipeline and version-management story.
+4. **Broad e2e coverage.** Kind-based e2e scenarios cover scaling,
+   rolling upgrades, ACL sync, observability, and the cluster-manager
+   integration.
+5. **CE constraints enforced at the webhook.** `size ≤ 8`, namespaces
+   ≤ 2, no XDR / TLS / EE-only features — all rejected with a clear
+   error before the CR is admitted. Honest, early failures over silent
+   misconfiguration.
+
+### 3. Cluster Manager — Web UI for cluster operations
+
+FastAPI backend + Next.js frontend. Deployed by ACKO as part of the
+Kubernetes stack; can also run standalone against an existing cluster.
+
+1. **Component reuse over duplication.** Shared frontend components live
+   in one place; new pages compose them rather than fork them.
+2. **Bounded read/write paths.** Data-table queries enforce limits,
+   pagination, and timeouts. The UI does not let a curious operator
+   accidentally stop-the-world a production cluster.
+3. **Tight ACKO integration.** Cluster lifecycle operations (create,
+   scale, upgrade, restart) are first-class in the UI.
+4. **Stable layout.** Layout and navigation structure are not changed
+   without a strong reason. Surprises in this area break operator
+   muscle memory.
+5. **Wizard-first cluster creation.** Creating a new ACKO cluster
+   through the wizard remains the recommended path; we keep its
+   ergonomics polished.
+6. **Backend ↔ frontend types are in sync.** Backend Pydantic models
+   and frontend TypeScript types in `lib/api/types.ts` are updated
+   together — changing one requires changing the other in the same PR.
+7. **Record browser handles large datasets.** Scans and queries against
+   high-cardinality namespaces remain responsive through limits,
+   pagination, and timeouts.
+
+### 4. `ackoctl` — CLI for the ACKO stack
+
+Same control plane the UI uses, scriptable from a terminal or an agent.
+
+1. **UI parity.** Any operation a human can do in Cluster Manager has
+   a CLI counterpart. The CLI is never strictly more limited than the
+   UI.
+2. **Scriptable output.** Every list/get command supports a structured
+   output mode (`--output json`) suitable for piping into `jq`, agents,
+   or other automation.
+3. **Stable command grammar.** Verbs and flags follow semver. Removing
+   or renaming a public verb requires a deprecation cycle.
+4. **Day-2 operations coverage.** Scaling, rolling upgrades, restart
+   workflows, ACL management, raw `asinfo`, namespace-level operations,
+   and AerospikeCluster CR introspection are all exposed.
+5. **Agent-friendly errors.** Failure messages are structured and
+   actionable — they identify the layer that failed (CR vs. operator
+   vs. data plane) so an agent can route the fix.
+
+### 5. Plugins — Claude Code plugin pack
+
+AI-assistant integration for the ecosystem.
+
+1. **Skills track upstream changes.** When `aerospike-py`'s public API
+   changes or ACKO's CRD changes shape, the corresponding skill is
+   updated in the same release cycle.
+2. **Debugging skill accuracy.** `acko-debugging` reflects real
+   troubleshooting decision trees — when an operator follows it, the
+   suggestions converge to the actual root cause, not to wallpaper.
+3. **Trigger discipline.** Skill descriptions trigger on the right
+   intents and do not over-fire. Off-topic triggers waste user
+   tokens and erode trust.
+4. **Single source of truth.** Skills reference the canonical docs in
+   each project rather than restating them; the plugin pack is a
+   *router*, not a duplicate of the documentation.


### PR DESCRIPTION
## Summary

`docs/docs/goals/project-goals.md` was a per-project goals list in Korean with no ecosystem-level framing. New readers had no answer to *"why does this ecosystem exist?"* without inferring it from the goals list, and `ackoctl` had no entry at all.

This rewrite turns the page into the **single source of truth** for both motivation and per-project contracts, in English, matching the framing on the new home page (#109).

## New structure

### 1. Why this ecosystem exists

Three problem statements with the concrete response from this ecosystem:

- The official Python client cannot carry an ML feature-store workload (→ `aerospike-py`)
- CE has no community Kubernetes story (→ ACKO + Cluster Manager + ackoctl)
- EE is out of reach inside large organisations (→ every component supports CE *and* EE)

### 2. Ecosystem-wide commitments

Three commitments that override project-local preferences when they conflict:

- **Open-source first, EE-compatible**
- **Cloud-native by default**
- **Agent-driven operations**

### 3. Per-project goals

Translated to English, ackoctl added as a first-class section, and each project's goals tightened so the intent is clear to external readers (not just maintainers).

| Project | Goal count | Notes |
|---------|------------|-------|
| `aerospike-py` | 6 | Restates the contract; canonical version stays under `.claude/skills/project-goals/` in the repo. |
| ACKO | 5 | CE-only constraints made explicit (size ≤ 8, no XDR/TLS). |
| Cluster Manager | 7 | Backend↔frontend type-sync rule preserved. |
| **ackoctl** | 5 | **New.** UI parity, structured output, semver grammar, agent-friendly errors. |
| Plugins | 4 | "Skills are a router, not a duplicate of the docs" added. |

## Follow-ups

Per-repo project-goals files (e.g. `aerospike-py/.claude/skills/project-goals/SKILL.md`) will be touched in separate PRs in their own repos to add a back-link to this canonical page.

## Test plan

- [x] `npm run build` — no broken links, no broken markdown
- [x] Frontmatter `last_updated` bumped to 2026-05-27, `ackoctl` added to `repos`
- [x] Visual scan: page renders cleanly on light/dark theme