### PR TITLE
docs(home): add EN / KO language toggle to WhySection

### DIFF
--- a/docs/docs/goals/project-goals.md
+++ b/docs/docs/goals/project-goals.md
@@ -62,10 +62,10 @@ rolling upgrades, warm restarts, ACL management, and an
 OpenTelemetry-instrumented data path — all driven by CRDs and exposed
 through both a UI and a CLI.
 
-### 3. Enterprise Edition is often out of reach inside large organisations
+### 3. Enterprise Edition is often out of reach inside large corporations
 
-Adopting Aerospike EE requires an org-level contract. Inside a large
-organisation, the procurement, legal, finance, and architecture sign-off
+Adopting Aerospike EE requires a corporate-level contract. Inside a large
+corporation, the procurement, legal, finance, and architecture sign-off
 chain becomes its own blocker — a classic *bell-the-cat* problem where
 everyone agrees EE would help, but nobody owns pushing the contract
 through, and the cost-justification burden lands on whoever raises their

--- a/docs/docs/goals/project-goals.md
+++ b/docs/docs/goals/project-goals.md
@@ -28,55 +28,59 @@ expected to align with these goals.
 
 ## Why this ecosystem exists
 
-Aerospike is a high-performance, low-latency NoSQL database and a natural fit
-for online feature stores and other latency-critical serving paths. Yet
-adopting Aerospike well today has three rough edges that this ecosystem was
-created to close.
+Aerospike is a high-performance, low-latency NoSQL database with strong fit
+for online feature stores and other latency-critical serving paths. However,
+three structural gaps make production adoption difficult today —
+particularly in large organizations and on Kubernetes. This ecosystem was
+created to close those gaps.
 
-### 1. The official Python client cannot carry an ML feature-store workload
+### 1. The upstream Python client cannot sustain ML feature-store workloads
 
-The upstream Python client wraps the C library through CFFI. The GIL is held
-across the I/O path, async support is bolted on, and the published type stubs
-drift from the runtime. For ML serving — where Python is the working
-language of the pipeline and feature-store reads must keep up with model
-inference — that gap is large enough to disqualify Aerospike from otherwise
-strong-fit use cases.
+The upstream Python client is a CFFI binding to the C library. The GIL is
+held across the I/O path, asynchronous I/O is not natively supported, and
+the published type stubs are not kept in sync with the runtime. For ML
+serving — where Python is the primary language of the pipeline and
+feature-store reads must keep pace with model inference — this overhead is
+significant enough to exclude Aerospike from workloads where it would
+otherwise be a strong fit.
 
-**Response:** `aerospike-py` — a from-scratch client written in Rust (PyO3).
-Native async, GIL release across the entire I/O path, NumPy batch
-fast-paths, and complete `.pyi` stubs. About **2.4× the throughput** of the
-official C client on standard mixed workloads.
+**Response:** `aerospike-py` — a client implemented from the ground up in
+Rust (PyO3), with native asynchronous I/O, GIL release across the entire
+I/O path, NumPy-aware batch interfaces, and complete `.pyi` stubs.
+Approximately **2.4× the throughput** of the upstream C client on standard
+mixed workloads.
 
-### 2. CE has no community Kubernetes story
+### 2. Aerospike CE has no community Kubernetes story
 
-Aerospike CE ships no community Kubernetes operator — the upstream AKO is
-Enterprise-only. There is no maintained web management UI, and the
-operational tooling assumes bare-metal deployments. Day-2 work on
-Kubernetes (scaling, rolling upgrades, warm restarts, ACL sync, dynamic
-config rollout) is left to each team to reinvent.
+Aerospike CE does not ship with a community-maintained Kubernetes operator
+— the upstream AKO is restricted to the Enterprise Edition. There is no
+maintained web management interface, and most operational tooling is
+designed for bare-metal deployments. Day-2 operations on Kubernetes —
+scaling, rolling upgrades, warm restarts, ACL synchronization, dynamic
+configuration changes — must be implemented independently by each team.
 
 **Response:** **ACKO** (a CE-focused Kubernetes operator), **Cluster
-Manager** (a FastAPI + Next.js web UI for cluster operations), and
-`ackoctl` (a CLI surface for both). Declarative cluster management,
-rolling upgrades, warm restarts, ACL management, and an
-OpenTelemetry-instrumented data path — all driven by CRDs and exposed
-through both a UI and a CLI.
+Manager** (a FastAPI + Next.js management interface), and `ackoctl` (a CLI
+surface). Declarative cluster lifecycle management, rolling upgrades,
+warm-restart workflows, ACL management, and an OpenTelemetry-instrumented
+data path — all defined through CRDs and exposed via both UI and CLI.
 
-### 3. Enterprise Edition is often out of reach inside large corporations
+### 3. Enterprise Edition adoption is not an individual-level decision
 
-Adopting Aerospike EE requires a corporate-level contract. Inside a large
-corporation, the procurement, legal, finance, and architecture sign-off
-chain becomes its own blocker — a classic *bell-the-cat* problem where
-everyone agrees EE would help, but nobody owns pushing the contract
-through, and the cost-justification burden lands on whoever raises their
-hand first. Many teams that should be on Aerospike never get past that
-gate.
+Aerospike Enterprise Edition is licensed at the organization level.
+Adoption requires a commercial agreement that involves procurement, legal,
+finance, and architecture review — by design, the decision sits above the
+individual engineer or team. As a result, teams that would benefit from
+Enterprise Edition features cannot adopt them on their own initiative, and
+Community Edition becomes the practical production baseline for those
+teams.
 
 **Response:** Every component in this ecosystem supports both Aerospike CE
-and EE. Teams ship on CE today with the same operator, the same client,
-and the same observability surface — and transparently move to EE later
-if and when the contract lands. The ecosystem unblocks adoption without
-forcing the EE decision up front.
+and the Enterprise Edition through a single, stable surface. Teams build
+and operate on CE today with the same operator, the same client, and the
+same observability stack, and migrate to EE if and when the organizational
+decision is made — without changes to application integration code or
+operational tooling.
 
 ---
 
@@ -85,29 +89,31 @@ forcing the EE decision up front.
 Three commitments cut across every project in the ecosystem and override
 project-local preferences when they conflict.
 
-### Open-source first, EE-compatible
+### Open-source first, Enterprise-Edition compatible
 
-Every component runs against both Aerospike CE and EE. Integrations, the
-operator, observability hooks, and operational tooling work identically on
-either edition. Adoption is never gated on procurement: CE today, EE later,
-no integration rewrite required.
+Every component operates against both Aerospike CE and the Enterprise
+Edition. Integrations, the operator, observability hooks, and operational
+tooling behave identically on either edition. Adoption is not gated on the
+procurement timeline: CE today, EE later, with no integration changes
+required.
 
 ### Cloud-native by default
 
-Kubernetes is a first-class deployment target, not an afterthought.
-Declarative cluster management lives in ACKO (CRDs + reconciliation),
-day-2 operations are exposed through a web UI (Cluster Manager) and a CLI
-(`ackoctl`), and the data path is OpenTelemetry-instrumented end to end.
-None of it requires an Enterprise licence.
+Kubernetes is a first-class deployment target rather than a secondary
+concern. Declarative cluster management is provided through ACKO (CRDs and
+reconciliation), day-2 operations are exposed through both a web
+management interface (Cluster Manager) and a CLI (`ackoctl`), and the data
+path is OpenTelemetry-instrumented end to end. None of these capabilities
+require an Enterprise Edition license.
 
 ### Agent-driven operations
 
-The same operational primitives that humans use through the UI and the CLI
-are exposed to autonomous agents. `ackoctl` produces structured output
-suitable for parsing, the Claude Code plugin pack ships nine skills covering
-deployment, debugging, day-2 ops, and e2e testing, and the project
-documentation is structured so agents can navigate the surface area without
-human translation.
+The operational primitives that human operators use through the UI and CLI
+are exposed equivalently to autonomous agents. `ackoctl` produces
+structured output suitable for programmatic consumption, the Claude Code
+plugin pack provides nine skills covering deployment, debugging, day-2
+operations, and end-to-end testing, and the project documentation is
+structured to be navigable by agents without manual translation.
 
 ---
 

--- a/docs/src/components/WhySection/index.tsx
+++ b/docs/src/components/WhySection/index.tsx
@@ -35,7 +35,7 @@ const CONTENT: Record<Lang, Content> = {
         excellent fit for online feature stores and other low-latency
         serving paths. Three practical gaps make it hard to actually ship
         on Aerospike at production quality today — especially inside large
-        organizations and on Kubernetes. The{' '}
+        corporations and on Kubernetes. The{' '}
         <strong>aerospike-ce-ecosystem</strong> closes those gaps with an
         open-source, cloud-native, agent-friendly toolchain.
       </>
@@ -93,11 +93,11 @@ const CONTENT: Record<Lang, Content> = {
       },
       {
         tag: '03 · EE gate',
-        title: 'Enterprise Edition is often out of reach inside large orgs',
+        title: 'Enterprise Edition is often out of reach inside large corporations',
         problem: (
           <>
-            Adopting Aerospike EE requires an org-level contract. Inside a
-            large organisation, procurement, legal, finance, and architecture
+            Adopting Aerospike EE requires a corporate-level contract. Inside
+            a large corporation, procurement, legal, finance, and architecture
             sign-offs become their own blocker — a classic <em>bell-the-cat</em>{' '}
             problem where everyone agrees EE would help, but no one owns
             pushing the contract through, and the cost-justification burden
@@ -158,7 +158,7 @@ const CONTENT: Record<Lang, Content> = {
       <>
         Aerospike는 고성능·저지연 NoSQL 데이터베이스로, 온라인 피처 스토어를
         비롯한 저지연 서빙 경로에 자연스럽게 들어맞는다. 그러나 실제로 운영
-        수준에서 Aerospike에 올라타려고 하면 — 특히 대규모 조직에서, 그리고
+        수준에서 Aerospike에 올라타려고 하면 — 특히 대기업 환경과
         쿠버네티스 위에서 — 현실적인 세 가지 갭이 가로막는다.{' '}
         <strong>aerospike-ce-ecosystem</strong>은 이 세 갭을 오픈소스 ·
         클라우드 네이티브 · 에이전트 친화적인 도구 모음으로 메운다.
@@ -215,10 +215,10 @@ const CONTENT: Record<Lang, Content> = {
       },
       {
         tag: '03 · EE 게이트',
-        title: '대규모 조직에서는 Enterprise Edition 도입 자체가 가로막힌다',
+        title: '대기업에서는 Enterprise Edition 도입 자체가 가로막힌다',
         problem: (
           <>
-            Aerospike EE 도입은 조직 수준의 계약이 필요하다. 큰 조직에서는
+            Aerospike EE 도입은 전사 차원의 계약이 필요하다. 대기업에서는
             구매·법무·재무·아키텍처 승인 체인 그 자체가 블로커가 된다 —
             모두가 EE가 도움이 된다는 데에는 동의하지만, 정작 계약을
             밀어붙이는 책임은 아무도 가져가지 않는, 전형적인{' '}

--- a/docs/src/components/WhySection/index.tsx
+++ b/docs/src/components/WhySection/index.tsx
@@ -28,89 +28,93 @@ interface Content {
 const CONTENT: Record<Lang, Content> = {
   en: {
     eyebrow: 'Why this ecosystem exists',
-    title: 'Aerospike is fast. Adopting it well, less so.',
+    title: 'Production-grade fundamentals, an incomplete adoption surface',
     lead: (
       <>
-        Aerospike is a high-performance, low-latency NoSQL database, and an
-        excellent fit for online feature stores and other low-latency
-        serving paths. Three practical gaps make it hard to actually ship
-        on Aerospike at production quality today — especially inside large
-        corporations and on Kubernetes. The{' '}
-        <strong>aerospike-ce-ecosystem</strong> closes those gaps with an
+        Aerospike is a high-performance, low-latency NoSQL database with strong
+        fit for online feature stores and other low-latency serving paths.
+        However, three structural gaps make production adoption difficult
+        today — particularly in large organizations and on Kubernetes. The{' '}
+        <strong>aerospike-ce-ecosystem</strong> addresses these gaps with an
         open-source, cloud-native, agent-friendly toolchain.
       </>
     ),
     problems: [
       {
-        tag: '01 · Performance',
-        title: 'The Python client cannot carry an ML feature-store workload',
+        tag: '01 · Client performance',
+        title: 'The upstream Python client cannot sustain ML feature-store workloads',
         problem: (
           <>
-            Aerospike is a natural fit for online feature stores —
-            sub-millisecond point reads, predictable tail latency, native
-            list/map types for feature vectors. But Python is the working
-            language of ML pipelines, and the official client wraps the C
-            library through CFFI: the GIL is held across the I/O path, async
-            support is bolted on, and the type stubs drift from the runtime.
-            At feature-store throughput, that gap is large enough to
-            disqualify Aerospike from otherwise good-fit use cases.
+            Aerospike maps cleanly to the online feature store profile —
+            sub-millisecond point reads, predictable tail latency, and native
+            list/map types for feature vectors. However, Python is the primary
+            language of ML pipelines, and the upstream client is a CFFI binding
+            to the C library: the GIL is held across the I/O path, asynchronous
+            I/O is not natively supported, and the published type stubs are not
+            kept in sync with the runtime. At feature-store throughput, the
+            resulting overhead is significant enough to exclude Aerospike from
+            workloads where it would otherwise be a strong fit.
           </>
         ),
         solution: (
           <>
-            →&nbsp;<code>aerospike-py</code> — a from-scratch client in
-            Rust&nbsp;(PyO3) with native async, GIL release across the I/O
-            path, NumPy batch fast-paths, and complete type stubs.
-            About <strong>2.4× the throughput</strong> of the official C
-            client on standard mixed workloads, with first-class support for
-            ML inference servers.
+            →&nbsp;<code>aerospike-py</code> — a client implemented from the
+            ground up in Rust&nbsp;(PyO3), exposing native asynchronous I/O,
+            GIL release across the entire I/O path, NumPy-aware batch
+            interfaces, and complete type stubs. Approximately{' '}
+            <strong>2.4× the throughput</strong> of the upstream C client on
+            standard mixed workloads, with first-class support for ML
+            inference servers.
           </>
         ),
       },
       {
-        tag: '02 · Cloud-native',
-        title: 'No CE-grade Kubernetes story',
+        tag: '02 · Cloud-native gap',
+        title: 'Aerospike CE has no community Kubernetes story',
         problem: (
           <>
-            Aerospike CE ships no community Kubernetes operator — the
-            upstream AKO is Enterprise-only. There is no maintained web
-            management UI, and most operational tooling assumes bare-metal
-            deployments. Day-2 operations on Kubernetes (scaling, rolling
-            upgrades, warm restarts, dynamic config) are left to teams to
-            reinvent.
+            Aerospike CE does not ship with a community-maintained Kubernetes
+            operator — the upstream AKO is restricted to the Enterprise
+            Edition. There is no maintained web management interface, and
+            most operational tooling is designed for bare-metal deployments.
+            Day-2 operations on Kubernetes — scaling, rolling upgrades,
+            warm restarts, dynamic configuration changes — must be
+            implemented independently by each team.
           </>
         ),
         solution: (
           <>
-            →&nbsp;<strong>ACKO</strong> (CE-focused operator)
-            +&nbsp;<strong>Cluster Manager</strong> (FastAPI + Next.js UI)
-            +&nbsp;<code>ackoctl</code> (CLI). Declarative cluster management,
-            scaling and rolling upgrades, warm-restart workflows, ACL
-            management, OpenTelemetry-instrumented data path — all driven by
-            CRDs and exposed through a UI and a CLI.
+            →&nbsp;<strong>ACKO</strong> (a CE-focused Kubernetes operator),{' '}
+            <strong>Cluster Manager</strong> (a FastAPI + Next.js management
+            interface), and <code>ackoctl</code> (a CLI surface). Declarative
+            cluster lifecycle management, rolling upgrades, warm-restart
+            workflows, ACL management, and an OpenTelemetry-instrumented data
+            path — all defined through CRDs and exposed via both UI and CLI.
           </>
         ),
       },
       {
-        tag: '03 · EE gate',
-        title: 'Enterprise Edition is often out of reach inside large corporations',
+        tag: '03 · License model',
+        title: 'Enterprise Edition adoption is not an individual-level decision',
         problem: (
           <>
-            Adopting Aerospike EE requires a corporate-level contract. Inside
-            a large corporation, procurement, legal, finance, and architecture
-            sign-offs become their own blocker — a classic <em>bell-the-cat</em>{' '}
-            problem where everyone agrees EE would help, but no one owns
-            pushing the contract through, and the cost-justification burden
-            lands on whoever raises their hand.
+            Aerospike Enterprise Edition is licensed at the organization
+            level. Adoption requires a commercial agreement that involves
+            procurement, legal, finance, and architecture review — by design,
+            the decision sits above the individual engineer or team. As a
+            result, teams that would benefit from Enterprise Edition features
+            cannot adopt them on their own initiative, and Community Edition
+            becomes the practical production baseline for those teams.
           </>
         ),
         solution: (
           <>
-            →&nbsp;Every component supports <strong>both CE and EE</strong>.
-            Teams ship on CE today, with the same operator, the same client,
-            the same observability surface — and transparently move to EE
-            later if and when the contract lands. The ecosystem unblocks
-            adoption without forcing the contract decision up front.
+            →&nbsp;Every component in this ecosystem supports both Aerospike
+            CE and the Enterprise Edition through a single, stable surface.
+            Teams can build and operate on CE today with the same operator,
+            client, and observability stack, and migrate to EE if and when
+            the organizational decision is made — without changes to
+            application integration code or operational tooling.
           </>
         ),
       },
@@ -118,12 +122,13 @@ const CONTENT: Record<Lang, Content> = {
     commitmentsTitle: 'What we ship',
     commitments: [
       {
-        title: 'Open-source first, EE-compatible',
+        title: 'Open-source first, Enterprise-Edition compatible',
         body: (
           <>
-            Every component runs against both Aerospike CE and EE, so
-            adoption is not gated on procurement. CE today, EE later, no
-            integration rewrite.
+            Every component operates against both Aerospike CE and the
+            Enterprise Edition. Adoption is not gated on the procurement
+            timeline — CE today, EE later, with no integration changes
+            required.
           </>
         ),
       },
@@ -131,9 +136,10 @@ const CONTENT: Record<Lang, Content> = {
         title: 'Cloud-native by default',
         body: (
           <>
-            Declarative Kubernetes management via ACKO, a real web UI for
-            cluster ops, and an OpenTelemetry-instrumented data path —
-            without an EE license.
+            Declarative Kubernetes management via ACKO, a maintained web
+            management interface for cluster operations, and an
+            OpenTelemetry-instrumented data path — without an Enterprise
+            Edition license.
           </>
         ),
       },
@@ -142,9 +148,9 @@ const CONTENT: Record<Lang, Content> = {
         body: (
           <>
             The same operational primitives are exposed through{' '}
-            <code>ackoctl</code> and a Claude Code plugin pack. Agents can
-            provision, scale, debug, and operate Aerospike clusters with the
-            same surface a human operator uses.
+            <code>ackoctl</code> and a Claude Code plugin pack. Autonomous
+            agents can provision, scale, debug, and operate Aerospike
+            clusters through the same surface a human operator would use.
           </>
         ),
       },
@@ -153,107 +159,114 @@ const CONTENT: Record<Lang, Content> = {
 
   ko: {
     eyebrow: '이 ecosystem이 존재하는 이유',
-    title: 'Aerospike는 빠르다. 다만 제대로 도입하기는 아직 쉽지 않다.',
+    title: '견고한 기반, 미완성된 도입 표면',
     lead: (
       <>
-        Aerospike는 고성능·저지연 NoSQL 데이터베이스로, 온라인 피처 스토어를
-        비롯한 저지연 서빙 경로에 자연스럽게 들어맞는다. 그러나 실제로 운영
-        수준에서 Aerospike에 올라타려고 하면 — 특히 대기업 환경과
-        쿠버네티스 위에서 — 현실적인 세 가지 갭이 가로막는다.{' '}
-        <strong>aerospike-ce-ecosystem</strong>은 이 세 갭을 오픈소스 ·
-        클라우드 네이티브 · 에이전트 친화적인 도구 모음으로 메운다.
+        Aerospike는 고성능·저지연 NoSQL 데이터베이스로, 온라인 피처
+        스토어를 비롯한 저지연 서빙 경로에 적합한 특성을 가진다. 그러나
+        실제 운영 환경에서의 도입을 가로막는 세 가지 구조적 갭이 존재한다
+        — 특히 대규모 조직과 쿠버네티스 환경에서 두드러진다.{' '}
+        <strong>aerospike-ce-ecosystem</strong>은 오픈소스 · 클라우드
+        네이티브 · 에이전트 친화적 도구를 통해 이 갭을 해소한다.
       </>
     ),
     problems: [
       {
-        tag: '01 · 성능',
-        title: 'Python 클라이언트가 ML 피처 스토어 워크로드를 감당하지 못한다',
+        tag: '01 · 클라이언트 성능',
+        title: '업스트림 Python 클라이언트로는 ML 피처 스토어 워크로드를 감당하기 어렵다',
         problem: (
           <>
-            Aerospike는 온라인 피처 스토어에 자연스럽게 어울린다 — 서브
-            밀리세컨드 포인트 리드, 예측 가능한 tail latency, 피처 벡터에 잘
-            맞는 list/map 네이티브 타입. 하지만 ML 파이프라인의 실무 언어는
-            Python이고, 공식 클라이언트는 C 라이브러리를 CFFI로 감싼 구조다.
-            I/O 경로 내내 GIL을 붙잡고, async는 외부에서 덧붙인 형태이며,
-            배포된 type stub은 런타임과 어긋난다. 피처 스토어 처리량에서는 이
-            격차가 충분히 커서, fit이 좋은 use case에서도 Aerospike를
-            후보에서 탈락시킨다.
+            Aerospike는 온라인 피처 스토어의 요구 사항에 잘 부합한다 —
+            서브밀리세컨드 포인트 리드, 예측 가능한 tail latency, 피처
+            벡터에 적합한 list/map 네이티브 타입. 그러나 ML 파이프라인의
+            주 언어는 Python이며, 업스트림 클라이언트는 C 라이브러리에
+            대한 CFFI 바인딩으로 구현되어 있다. I/O 경로 전반에서 GIL이
+            유지되고, 비동기 I/O가 네이티브로 지원되지 않으며, 게시된
+            type stub은 런타임과 일치하지 않는다. 피처 스토어 처리량
+            수준에서는 이 오버헤드가 충분히 커서, fit이 좋은 워크로드에서
+            조차 Aerospike가 채택 후보에서 제외되는 결과로 이어진다.
           </>
         ),
         solution: (
           <>
             →&nbsp;<code>aerospike-py</code> — Rust(PyO3) 기반으로 처음부터
-            다시 만든 클라이언트. 네이티브 async, I/O 경로 전체에서 GIL
-            release, NumPy 배치 fast-path, 완전한 type stub. 표준 mixed
-            워크로드에서 공식 C 클라이언트 대비{' '}
-            <strong>약 2.4× 처리량</strong>. ML 추론 서버를 1급 지원한다.
+            다시 구현한 클라이언트. 네이티브 비동기 I/O, I/O 경로 전체에서의
+            GIL release, NumPy 인지 배치 인터페이스, 완전한 type stub을
+            제공한다. 표준 mixed 워크로드 기준으로 업스트림 C 클라이언트
+            대비 <strong>약 2.4배의 처리량</strong>을 보이며, ML 추론
+            서버를 1급으로 지원한다.
           </>
         ),
       },
       {
-        tag: '02 · 클라우드 네이티브',
-        title: 'CE 등급의 쿠버네티스 스토리가 없다',
+        tag: '02 · 클라우드 네이티브 갭',
+        title: 'Aerospike CE에는 커뮤니티 수준의 쿠버네티스 스토리가 없다',
         problem: (
           <>
-            Aerospike CE에는 커뮤니티 쿠버네티스 오퍼레이터가 없다 — 업스트림
-            AKO는 Enterprise 전용이다. 유지보수되는 웹 관리 UI도 없고, 대부분의
-            운영 도구가 bare-metal 배포를 전제로 한다. 쿠버네티스 위 day-2
-            운영(스케일링, 롤링 업그레이드, warm restart, 동적 설정 변경)은
-            팀마다 다시 발명해야 한다.
+            Aerospike CE는 커뮤니티가 유지보수하는 쿠버네티스 오퍼레이터를
+            제공하지 않으며, 업스트림 AKO는 Enterprise Edition에만
+            한정된다. 유지보수되는 웹 관리 인터페이스도 없고, 대부분의
+            운영 도구는 bare-metal 배포를 전제로 설계되어 있다. 쿠버네티스
+            위에서의 day-2 운영 — 스케일링, 롤링 업그레이드, warm restart,
+            동적 설정 변경 등 — 은 팀마다 개별적으로 구현해야 한다.
           </>
         ),
         solution: (
           <>
-            →&nbsp;<strong>ACKO</strong>(CE 전용 오퍼레이터) +{' '}
-            <strong>Cluster Manager</strong>(FastAPI + Next.js UI) +{' '}
-            <code>ackoctl</code>(CLI). 선언적 클러스터 관리, 스케일링과 롤링
-            업그레이드, warm-restart 워크플로우, ACL 관리, OpenTelemetry로
-            계측된 데이터 경로 — 모두 CRD로 제어하고 UI와 CLI 양쪽에서
-            노출한다.
+            →&nbsp;<strong>ACKO</strong>(CE 전용 쿠버네티스 오퍼레이터),{' '}
+            <strong>Cluster Manager</strong>(FastAPI + Next.js 기반 관리
+            인터페이스), <code>ackoctl</code>(CLI 표면). 선언적 클러스터
+            라이프사이클 관리, 롤링 업그레이드, warm-restart 워크플로우,
+            ACL 관리, OpenTelemetry로 계측된 데이터 경로 — 모두 CRD로
+            정의하고 UI와 CLI 양쪽에서 노출한다.
           </>
         ),
       },
       {
-        tag: '03 · EE 게이트',
-        title: '대기업에서는 Enterprise Edition 도입 자체가 가로막힌다',
+        tag: '03 · 라이선스 모델',
+        title: 'Enterprise Edition 도입은 개인 차원에서 결정할 수 있는 사안이 아니다',
         problem: (
           <>
-            Aerospike EE 도입은 전사 차원의 계약이 필요하다. 대기업에서는
-            구매·법무·재무·아키텍처 승인 체인 그 자체가 블로커가 된다 —
-            모두가 EE가 도움이 된다는 데에는 동의하지만, 정작 계약을
-            밀어붙이는 책임은 아무도 가져가지 않는, 전형적인{' '}
-            <em>고양이 목에 방울 달기</em> 문제다. 비용 정당화의 부담은 손을
-            든 사람에게 떨어진다.
+            Aerospike Enterprise Edition은 조직 단위로 라이선스가
+            발급된다. 도입을 위해서는 구매·법무·재무·아키텍처 검토를
+            수반하는 상업 계약이 필요하며, 결정 권한은 설계상 개별
+            엔지니어나 팀의 범위를 벗어난다. 그 결과, EE 기능의 이점을
+            누릴 수 있는 팀이라 하더라도 자체 판단으로 도입하기는 어렵고,
+            해당 팀에는 Community Edition이 실질적인 프로덕션 기준이
+            된다.
           </>
         ),
         solution: (
           <>
-            →&nbsp;모든 컴포넌트가 <strong>CE와 EE를 동시에 지원</strong>한다.
-            동일한 오퍼레이터, 동일한 클라이언트, 동일한 observability 표면을
-            그대로 둔 채로 오늘 CE로 ship할 수 있고, 계약이 들어오면 EE로
-            그대로 전환한다. 계약 결정을 앞단에서 강제하지 않으면서 도입
-            자체를 풀어준다.
+            →&nbsp;이 ecosystem의 모든 컴포넌트는 단일한 안정 표면을 통해
+            Aerospike CE와 Enterprise Edition을 동시에 지원한다. 동일한
+            오퍼레이터, 클라이언트, observability 스택을 그대로 사용하면서
+            오늘은 CE로 구축·운영하고, 조직 차원의 결정이 이루어지는
+            시점에 EE로 이전한다 — 애플리케이션 통합 코드나 운영 도구의
+            변경 없이.
           </>
         ),
       },
     ],
-    commitmentsTitle: '우리가 ship하는 것',
+    commitmentsTitle: 'What we ship',
     commitments: [
       {
-        title: '오픈소스 우선, EE 호환',
+        title: '오픈소스 우선, Enterprise Edition 호환',
         body: (
           <>
-            모든 컴포넌트가 Aerospike CE와 EE 양쪽에서 동작한다. 도입이 구매
-            절차에 묶이지 않는다. 오늘은 CE, 나중에 EE, 통합 코드 재작성 없음.
+            모든 컴포넌트가 Aerospike CE와 Enterprise Edition 양쪽에서
+            동작한다. 도입이 구매 절차의 일정에 묶이지 않는다 — 오늘은
+            CE, 추후 EE, 통합 코드 변경 없이.
           </>
         ),
       },
       {
-        title: '클라우드 네이티브 기본 채택',
+        title: '클라우드 네이티브 우선',
         body: (
           <>
-            ACKO를 통한 선언적 쿠버네티스 관리, 실제 쓸 만한 클러스터 운영 웹
-            UI, OpenTelemetry로 계측된 데이터 경로 — EE 라이선스 없이.
+            ACKO를 통한 선언적 쿠버네티스 관리, 유지보수되는 클러스터
+            운영 웹 인터페이스, OpenTelemetry로 계측된 데이터 경로 —
+            Enterprise Edition 라이선스 없이.
           </>
         ),
       },
@@ -261,10 +274,10 @@ const CONTENT: Record<Lang, Content> = {
         title: '에이전트 주도 운영',
         body: (
           <>
-            동일한 운영 primitive를 <code>ackoctl</code>과 Claude Code 플러그인
-            팩으로 노출한다. 에이전트는 사람 운영자가 쓰는 것과 같은 표면에서
-            Aerospike 클러스터를 provisioning · 스케일링 · 디버깅 · 운영할 수
-            있다.
+            동일한 운영 primitive를 <code>ackoctl</code>과 Claude Code
+            플러그인 팩을 통해 노출한다. 자율 에이전트는 사람 운영자와
+            동일한 표면에서 Aerospike 클러스터를 provisioning · 스케일링 ·
+            디버깅 · 운영할 수 있다.
           </>
         ),
       },

--- a/docs/src/components/WhySection/index.tsx
+++ b/docs/src/components/WhySection/index.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, {useState} from 'react';
 import clsx from 'clsx';
 import styles from './styles.module.css';
+
+type Lang = 'en' | 'ko';
 
 interface Problem {
   tag: string;
@@ -9,151 +11,327 @@ interface Problem {
   solution: React.ReactNode;
 }
 
-const PROBLEMS: Problem[] = [
-  {
-    tag: '01 · Performance',
-    title: 'The Python client cannot carry an ML feature-store workload',
-    problem: (
-      <>
-        Aerospike is a natural fit for online feature stores — sub-millisecond
-        point reads, predictable tail latency, native list/map types for
-        feature vectors. But Python is the working language of ML pipelines,
-        and the official client wraps the C library through CFFI:
-        the GIL is held across the I/O path, async support is bolted on,
-        and the type stubs drift from the runtime. At feature-store
-        throughput, that gap is large enough to disqualify Aerospike from
-        otherwise good-fit use cases.
-      </>
-    ),
-    solution: (
-      <>
-        →&nbsp;<code>aerospike-py</code> — a from-scratch client in
-        Rust&nbsp;(PyO3) with native async, GIL release across the I/O path,
-        NumPy batch fast-paths, and complete type stubs. About <strong>2.4×
-        the throughput</strong> of the official C client on standard mixed
-        workloads, with first-class support for ML inference servers.
-      </>
-    ),
-  },
-  {
-    tag: '02 · Cloud-native',
-    title: 'No CE-grade Kubernetes story',
-    problem: (
-      <>
-        Aerospike CE ships no community Kubernetes operator — the upstream
-        AKO is Enterprise-only. There is no maintained web management UI,
-        and most operational tooling assumes bare-metal deployments.
-        Day-2 operations on Kubernetes (scaling, rolling upgrades, warm
-        restarts, dynamic config) are left to teams to reinvent.
-      </>
-    ),
-    solution: (
-      <>
-        →&nbsp;<strong>ACKO</strong> (CE-focused operator)
-        +&nbsp;<strong>Cluster Manager</strong> (FastAPI + Next.js UI)
-        +&nbsp;<code>ackoctl</code> (CLI). Declarative cluster management,
-        scaling and rolling upgrades, warm-restart workflows, ACL
-        management, OpenTelemetry-instrumented data path — all driven by
-        CRDs and exposed through a UI and a CLI.
-      </>
-    ),
-  },
-  {
-    tag: '03 · EE gate',
-    title: 'Enterprise Edition is often out of reach inside large orgs',
-    problem: (
-      <>
-        Adopting Aerospike EE requires an org-level contract. Inside a
-        large organization, procurement, legal, finance, and architecture
-        sign-offs become their own blocker — a classic <em>bell the
-        cat</em> problem where everyone agrees EE would help, but no one
-        owns pushing the contract through, and the cost-justification
-        burden lands on whoever raises their hand.
-      </>
-    ),
-    solution: (
-      <>
-        →&nbsp;Every component supports <strong>both CE and EE</strong>.
-        Teams ship on CE today, with the same operator, the same client,
-        the same observability surface — and transparently move to EE
-        later if and when the contract lands. The ecosystem unblocks
-        adoption without forcing the contract decision up front.
-      </>
-    ),
-  },
-];
+interface Commitment {
+  title: string;
+  body: React.ReactNode;
+}
 
-const COMMITMENTS: {title: string; body: React.ReactNode}[] = [
-  {
-    title: 'Open-source first, EE-compatible',
-    body: (
+interface Content {
+  eyebrow: string;
+  title: string;
+  lead: React.ReactNode;
+  problems: Problem[];
+  commitmentsTitle: string;
+  commitments: Commitment[];
+}
+
+const CONTENT: Record<Lang, Content> = {
+  en: {
+    eyebrow: 'Why this ecosystem exists',
+    title: 'Aerospike is fast. Adopting it well, less so.',
+    lead: (
       <>
-        Every component runs against both Aerospike CE and EE, so adoption
-        is not gated on procurement. CE today, EE later, no integration
-        rewrite.
+        Aerospike is a high-performance, low-latency NoSQL database, and an
+        excellent fit for online feature stores and other low-latency
+        serving paths. Three practical gaps make it hard to actually ship
+        on Aerospike at production quality today — especially inside large
+        organizations and on Kubernetes. The{' '}
+        <strong>aerospike-ce-ecosystem</strong> closes those gaps with an
+        open-source, cloud-native, agent-friendly toolchain.
       </>
     ),
+    problems: [
+      {
+        tag: '01 · Performance',
+        title: 'The Python client cannot carry an ML feature-store workload',
+        problem: (
+          <>
+            Aerospike is a natural fit for online feature stores —
+            sub-millisecond point reads, predictable tail latency, native
+            list/map types for feature vectors. But Python is the working
+            language of ML pipelines, and the official client wraps the C
+            library through CFFI: the GIL is held across the I/O path, async
+            support is bolted on, and the type stubs drift from the runtime.
+            At feature-store throughput, that gap is large enough to
+            disqualify Aerospike from otherwise good-fit use cases.
+          </>
+        ),
+        solution: (
+          <>
+            →&nbsp;<code>aerospike-py</code> — a from-scratch client in
+            Rust&nbsp;(PyO3) with native async, GIL release across the I/O
+            path, NumPy batch fast-paths, and complete type stubs.
+            About <strong>2.4× the throughput</strong> of the official C
+            client on standard mixed workloads, with first-class support for
+            ML inference servers.
+          </>
+        ),
+      },
+      {
+        tag: '02 · Cloud-native',
+        title: 'No CE-grade Kubernetes story',
+        problem: (
+          <>
+            Aerospike CE ships no community Kubernetes operator — the
+            upstream AKO is Enterprise-only. There is no maintained web
+            management UI, and most operational tooling assumes bare-metal
+            deployments. Day-2 operations on Kubernetes (scaling, rolling
+            upgrades, warm restarts, dynamic config) are left to teams to
+            reinvent.
+          </>
+        ),
+        solution: (
+          <>
+            →&nbsp;<strong>ACKO</strong> (CE-focused operator)
+            +&nbsp;<strong>Cluster Manager</strong> (FastAPI + Next.js UI)
+            +&nbsp;<code>ackoctl</code> (CLI). Declarative cluster management,
+            scaling and rolling upgrades, warm-restart workflows, ACL
+            management, OpenTelemetry-instrumented data path — all driven by
+            CRDs and exposed through a UI and a CLI.
+          </>
+        ),
+      },
+      {
+        tag: '03 · EE gate',
+        title: 'Enterprise Edition is often out of reach inside large orgs',
+        problem: (
+          <>
+            Adopting Aerospike EE requires an org-level contract. Inside a
+            large organisation, procurement, legal, finance, and architecture
+            sign-offs become their own blocker — a classic <em>bell-the-cat</em>{' '}
+            problem where everyone agrees EE would help, but no one owns
+            pushing the contract through, and the cost-justification burden
+            lands on whoever raises their hand.
+          </>
+        ),
+        solution: (
+          <>
+            →&nbsp;Every component supports <strong>both CE and EE</strong>.
+            Teams ship on CE today, with the same operator, the same client,
+            the same observability surface — and transparently move to EE
+            later if and when the contract lands. The ecosystem unblocks
+            adoption without forcing the contract decision up front.
+          </>
+        ),
+      },
+    ],
+    commitmentsTitle: 'What we ship',
+    commitments: [
+      {
+        title: 'Open-source first, EE-compatible',
+        body: (
+          <>
+            Every component runs against both Aerospike CE and EE, so
+            adoption is not gated on procurement. CE today, EE later, no
+            integration rewrite.
+          </>
+        ),
+      },
+      {
+        title: 'Cloud-native by default',
+        body: (
+          <>
+            Declarative Kubernetes management via ACKO, a real web UI for
+            cluster ops, and an OpenTelemetry-instrumented data path —
+            without an EE license.
+          </>
+        ),
+      },
+      {
+        title: 'Agent-driven operations',
+        body: (
+          <>
+            The same operational primitives are exposed through{' '}
+            <code>ackoctl</code> and a Claude Code plugin pack. Agents can
+            provision, scale, debug, and operate Aerospike clusters with the
+            same surface a human operator uses.
+          </>
+        ),
+      },
+    ],
   },
-  {
-    title: 'Cloud-native by default',
-    body: (
+
+  ko: {
+    eyebrow: '이 ecosystem이 존재하는 이유',
+    title: 'Aerospike는 빠르다. 다만 제대로 도입하기는 아직 쉽지 않다.',
+    lead: (
       <>
-        Declarative Kubernetes management via ACKO, a real web UI for cluster
-        ops, and an OpenTelemetry-instrumented data path — without an EE
-        license.
+        Aerospike는 고성능·저지연 NoSQL 데이터베이스로, 온라인 피처 스토어를
+        비롯한 저지연 서빙 경로에 자연스럽게 들어맞는다. 그러나 실제로 운영
+        수준에서 Aerospike에 올라타려고 하면 — 특히 대규모 조직에서, 그리고
+        쿠버네티스 위에서 — 현실적인 세 가지 갭이 가로막는다.{' '}
+        <strong>aerospike-ce-ecosystem</strong>은 이 세 갭을 오픈소스 ·
+        클라우드 네이티브 · 에이전트 친화적인 도구 모음으로 메운다.
       </>
     ),
+    problems: [
+      {
+        tag: '01 · 성능',
+        title: 'Python 클라이언트가 ML 피처 스토어 워크로드를 감당하지 못한다',
+        problem: (
+          <>
+            Aerospike는 온라인 피처 스토어에 자연스럽게 어울린다 — 서브
+            밀리세컨드 포인트 리드, 예측 가능한 tail latency, 피처 벡터에 잘
+            맞는 list/map 네이티브 타입. 하지만 ML 파이프라인의 실무 언어는
+            Python이고, 공식 클라이언트는 C 라이브러리를 CFFI로 감싼 구조다.
+            I/O 경로 내내 GIL을 붙잡고, async는 외부에서 덧붙인 형태이며,
+            배포된 type stub은 런타임과 어긋난다. 피처 스토어 처리량에서는 이
+            격차가 충분히 커서, fit이 좋은 use case에서도 Aerospike를
+            후보에서 탈락시킨다.
+          </>
+        ),
+        solution: (
+          <>
+            →&nbsp;<code>aerospike-py</code> — Rust(PyO3) 기반으로 처음부터
+            다시 만든 클라이언트. 네이티브 async, I/O 경로 전체에서 GIL
+            release, NumPy 배치 fast-path, 완전한 type stub. 표준 mixed
+            워크로드에서 공식 C 클라이언트 대비{' '}
+            <strong>약 2.4× 처리량</strong>. ML 추론 서버를 1급 지원한다.
+          </>
+        ),
+      },
+      {
+        tag: '02 · 클라우드 네이티브',
+        title: 'CE 등급의 쿠버네티스 스토리가 없다',
+        problem: (
+          <>
+            Aerospike CE에는 커뮤니티 쿠버네티스 오퍼레이터가 없다 — 업스트림
+            AKO는 Enterprise 전용이다. 유지보수되는 웹 관리 UI도 없고, 대부분의
+            운영 도구가 bare-metal 배포를 전제로 한다. 쿠버네티스 위 day-2
+            운영(스케일링, 롤링 업그레이드, warm restart, 동적 설정 변경)은
+            팀마다 다시 발명해야 한다.
+          </>
+        ),
+        solution: (
+          <>
+            →&nbsp;<strong>ACKO</strong>(CE 전용 오퍼레이터) +{' '}
+            <strong>Cluster Manager</strong>(FastAPI + Next.js UI) +{' '}
+            <code>ackoctl</code>(CLI). 선언적 클러스터 관리, 스케일링과 롤링
+            업그레이드, warm-restart 워크플로우, ACL 관리, OpenTelemetry로
+            계측된 데이터 경로 — 모두 CRD로 제어하고 UI와 CLI 양쪽에서
+            노출한다.
+          </>
+        ),
+      },
+      {
+        tag: '03 · EE 게이트',
+        title: '대규모 조직에서는 Enterprise Edition 도입 자체가 가로막힌다',
+        problem: (
+          <>
+            Aerospike EE 도입은 조직 수준의 계약이 필요하다. 큰 조직에서는
+            구매·법무·재무·아키텍처 승인 체인 그 자체가 블로커가 된다 —
+            모두가 EE가 도움이 된다는 데에는 동의하지만, 정작 계약을
+            밀어붙이는 책임은 아무도 가져가지 않는, 전형적인{' '}
+            <em>고양이 목에 방울 달기</em> 문제다. 비용 정당화의 부담은 손을
+            든 사람에게 떨어진다.
+          </>
+        ),
+        solution: (
+          <>
+            →&nbsp;모든 컴포넌트가 <strong>CE와 EE를 동시에 지원</strong>한다.
+            동일한 오퍼레이터, 동일한 클라이언트, 동일한 observability 표면을
+            그대로 둔 채로 오늘 CE로 ship할 수 있고, 계약이 들어오면 EE로
+            그대로 전환한다. 계약 결정을 앞단에서 강제하지 않으면서 도입
+            자체를 풀어준다.
+          </>
+        ),
+      },
+    ],
+    commitmentsTitle: '우리가 ship하는 것',
+    commitments: [
+      {
+        title: '오픈소스 우선, EE 호환',
+        body: (
+          <>
+            모든 컴포넌트가 Aerospike CE와 EE 양쪽에서 동작한다. 도입이 구매
+            절차에 묶이지 않는다. 오늘은 CE, 나중에 EE, 통합 코드 재작성 없음.
+          </>
+        ),
+      },
+      {
+        title: '클라우드 네이티브 기본 채택',
+        body: (
+          <>
+            ACKO를 통한 선언적 쿠버네티스 관리, 실제 쓸 만한 클러스터 운영 웹
+            UI, OpenTelemetry로 계측된 데이터 경로 — EE 라이선스 없이.
+          </>
+        ),
+      },
+      {
+        title: '에이전트 주도 운영',
+        body: (
+          <>
+            동일한 운영 primitive를 <code>ackoctl</code>과 Claude Code 플러그인
+            팩으로 노출한다. 에이전트는 사람 운영자가 쓰는 것과 같은 표면에서
+            Aerospike 클러스터를 provisioning · 스케일링 · 디버깅 · 운영할 수
+            있다.
+          </>
+        ),
+      },
+    ],
   },
-  {
-    title: 'Agent-driven operations',
-    body: (
-      <>
-        The same operational primitives are exposed through{' '}
-        <code>ackoctl</code> and a Claude Code plugin pack. Agents can
-        provision, scale, debug, and operate Aerospike clusters with the
-        same surface a human operator uses.
-      </>
-    ),
-  },
-];
+};
+
+function LangTabs({lang, onChange}: {lang: Lang; onChange: (l: Lang) => void}): React.JSX.Element {
+  return (
+    <div className={styles.langTabs} role="tablist" aria-label="Content language">
+      <button
+        type="button"
+        role="tab"
+        aria-selected={lang === 'en'}
+        className={clsx(styles.langTab, lang === 'en' && styles.langTabActive)}
+        onClick={() => onChange('en')}
+      >
+        EN
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={lang === 'ko'}
+        className={clsx(styles.langTab, lang === 'ko' && styles.langTabActive)}
+        onClick={() => onChange('ko')}
+      >
+        한국어
+      </button>
+    </div>
+  );
+}
 
 export default function WhySection(): React.JSX.Element {
+  const [lang, setLang] = useState<Lang>('en');
+  const c = CONTENT[lang];
+
   return (
-    <section className={clsx('container', styles.section)}>
-      <div className={styles.intro}>
-        <span className={styles.eyebrow}>Why this ecosystem exists</span>
-        <h2 className={styles.title}>
-          Aerospike is fast. Adopting it well, less so.
-        </h2>
-        <p className={styles.lead}>
-          Aerospike is a high-performance, low-latency NoSQL database, and an
-          excellent fit for online feature stores and other low-latency
-          serving paths. Three practical gaps make it hard to actually ship
-          on Aerospike at production quality today — especially inside large
-          organizations and on Kubernetes. The <strong>aerospike-ce-ecosystem</strong> closes
-          those gaps with an open-source, cloud-native, agent-friendly toolchain.
-        </p>
+    <section
+      className={clsx('container', styles.section)}
+      lang={lang === 'ko' ? 'ko' : 'en'}
+    >
+      <div className={styles.introRow}>
+        <div className={styles.intro}>
+          <span className={styles.eyebrow}>{c.eyebrow}</span>
+          <h2 className={styles.title}>{c.title}</h2>
+          <p className={styles.lead}>{c.lead}</p>
+        </div>
+        <LangTabs lang={lang} onChange={setLang} />
       </div>
 
-      <div className={clsx('row', styles.problemRow)}>
-        {PROBLEMS.map((p) => (
-          <div key={p.tag} className={clsx('col col--4', styles.problemCol)}>
-            <article className={styles.problemCard}>
-              <div className={styles.problemTag}>{p.tag}</div>
-              <h3 className={styles.problemTitle}>{p.title}</h3>
-              <p className={styles.problemBody}>{p.problem}</p>
-              <p className={styles.problemSolution}>{p.solution}</p>
-            </article>
-          </div>
+      <div className={styles.problemRow}>
+        {c.problems.map((p) => (
+          <article key={p.tag} className={styles.problemCard}>
+            <div className={styles.problemTag}>{p.tag}</div>
+            <h3 className={styles.problemTitle}>{p.title}</h3>
+            <p className={styles.problemBody}>{p.problem}</p>
+            <p className={styles.problemSolution}>{p.solution}</p>
+          </article>
         ))}
       </div>
 
       <div className={styles.commitmentsBlock}>
-        <h3 className={styles.commitmentsTitle}>What we ship</h3>
+        <h3 className={styles.commitmentsTitle}>{c.commitmentsTitle}</h3>
         <ul className={styles.commitmentsList}>
-          {COMMITMENTS.map((c) => (
-            <li key={c.title}>
-              <strong>{c.title}.</strong> {c.body}
+          {c.commitments.map((cm) => (
+            <li key={cm.title}>
+              <strong>{cm.title}.</strong> {cm.body}
             </li>
           ))}
         </ul>

--- a/docs/src/components/WhySection/styles.module.css
+++ b/docs/src/components/WhySection/styles.module.css
@@ -2,10 +2,54 @@
   padding: 3.5rem 0 1rem;
 }
 
-/* ── Intro ───────────────────────────────────────────────────── */
+/* ── Intro + language tabs ───────────────────────────────────── */
+.introRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 24px;
+  margin-bottom: 2.25rem;
+}
+@media (max-width: 720px) {
+  .introRow {
+    flex-direction: column-reverse;
+    align-items: stretch;
+    gap: 12px;
+  }
+}
 .intro {
   max-width: 760px;
-  margin-bottom: 2.25rem;
+  flex: 1;
+}
+.langTabs {
+  display: inline-flex;
+  padding: 3px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 999px;
+  background: var(--ifm-card-background-color);
+  flex-shrink: 0;
+}
+.langTab {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  padding: 6px 14px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  font-family: inherit;
+}
+.langTab:hover {
+  color: var(--ifm-color-content);
+}
+.langTabActive {
+  background: var(--ifm-color-primary);
+  color: var(--ifm-color-primary-contrast-background, #fff);
+}
+.langTabActive:hover {
+  color: var(--ifm-color-primary-contrast-background, #fff);
 }
 .eyebrow {
   display: inline-flex;
@@ -44,15 +88,20 @@
 
 /* ── Problem grid ────────────────────────────────────────────── */
 .problemRow {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
   align-items: stretch;
-}
-.problemCol {
   margin-bottom: 1rem;
+}
+@media (max-width: 1024px) {
+  .problemRow {
+    grid-template-columns: 1fr;
+  }
 }
 .problemCard {
   display: flex;
   flex-direction: column;
-  height: 100%;
   padding: 22px 22px 20px;
   border: 1px solid var(--ifm-color-emphasis-200);
   border-radius: 14px;


### PR DESCRIPTION
## Summary

The motivation copy on the home page is now switchable between English and 한국어 via a small pill toggle in the top-right of the WhySection intro row.

## What changed

- `CONTENT` map keyed by `'en' | 'ko'` holds the eyebrow, title, lead, three problem cards, and three commitments in both languages.
- The `LangTabs` control is a roving pill toggle (`role="tablist"` + `aria-selected`).
- Switching the language also updates the `<section lang="…">` attribute so screen readers pick the right pronunciation.
- Problem grid moved off Docusaurus `row` + `col col--4` to a 3-column CSS grid; collapses to a single column at <1024px, and the intro row stacks the tabs above the title at <720px.

## Test plan

- [x] `npm run typecheck`, `npm run build` — pass
- [x] Korean copy reviewed for natural phrasing (not a literal translation)
- [x] Visual check: tab switching is instant, no layout shift