### PR TITLE
docs: polish motivation copy — simpler titles, refined terminology

### DIFF
--- a/docs/docs/goals/project-goals.md
+++ b/docs/docs/goals/project-goals.md
@@ -34,9 +34,9 @@ three structural gaps make production adoption difficult today —
 particularly in large organizations and on Kubernetes. This ecosystem was
 created to close those gaps.
 
-### 1. The upstream Python client cannot sustain ML feature-store workloads
+### 1. The official Python client cannot sustain ML feature-store workloads
 
-The upstream Python client is a CFFI binding to the C library. The GIL is
+The official Python client is a CFFI binding to the C library. The GIL is
 held across the I/O path, asynchronous I/O is not natively supported, and
 the published type stubs are not kept in sync with the runtime. For ML
 serving — where Python is the primary language of the pipeline and
@@ -47,13 +47,13 @@ otherwise be a strong fit.
 **Response:** `aerospike-py` — a client implemented from the ground up in
 Rust (PyO3), with native asynchronous I/O, GIL release across the entire
 I/O path, NumPy-aware batch interfaces, and complete `.pyi` stubs.
-Approximately **2.4× the throughput** of the upstream C client on standard
+Approximately **2.4× the throughput** of the official C client on standard
 mixed workloads.
 
-### 2. Aerospike CE has no community Kubernetes story
+### 2. Aerospike CE has no community-maintained cloud-native ecosystem
 
 Aerospike CE does not ship with a community-maintained Kubernetes operator
-— the upstream AKO is restricted to the Enterprise Edition. There is no
+— the official AKO is restricted to the Enterprise Edition. There is no
 maintained web management interface, and most operational tooling is
 designed for bare-metal deployments. Day-2 operations on Kubernetes —
 scaling, rolling upgrades, warm restarts, ACL synchronization, dynamic
@@ -97,14 +97,15 @@ tooling behave identically on either edition. Adoption is not gated on the
 procurement timeline: CE today, EE later, with no integration changes
 required.
 
-### Cloud-native by default
+### Cloud-native advancement
 
 Kubernetes is a first-class deployment target rather than a secondary
-concern. Declarative cluster management is provided through ACKO (CRDs and
-reconciliation), day-2 operations are exposed through both a web
-management interface (Cluster Manager) and a CLI (`ackoctl`), and the data
-path is OpenTelemetry-instrumented end to end. None of these capabilities
-require an Enterprise Edition license.
+concern, and the ecosystem actively advances the cloud-native story for
+Aerospike CE. Declarative cluster management is provided through ACKO
+(CRDs and reconciliation), day-2 operations are exposed through both a
+web management interface (Cluster Manager) and a CLI (`ackoctl`), and the
+data path is OpenTelemetry-instrumented end to end. None of these
+capabilities require an Enterprise Edition license.
 
 ### Agent-driven operations
 
@@ -126,11 +127,11 @@ Detailed goals and reference docs live under
 restated here so external readers can follow the contract.
 
 1. **Hold the performance gap.** Maintain the throughput and latency
-   advantage over the upstream C client. The Rust (PyO3) layer always
+   advantage over the official C client. The Rust (PyO3) layer always
    does the heavy lifting; Python is a thin wrapper.
 2. **Track `aerospike-client-rust` v2.** Stay current with the upstream
-   Rust crate as it evolves; pick up new features behind opt-in flags
-   when they land.
+   `aerospike-client-rust` crate as it evolves; pick up new features
+   behind opt-in flags when they land.
 3. **NumPy batch surface.** `batch_read_numpy` and `batch_write_numpy`
    keep working at production quality for ML feature-store workloads.
 4. **First-class observability.** Logging, Prometheus metrics, and

--- a/docs/src/components/WhySection/index.tsx
+++ b/docs/src/components/WhySection/index.tsx
@@ -46,28 +46,18 @@ const CONTENT: Record<Lang, Content> = {
         tag: '01 · Client performance',
         title: 'The official Python client cannot sustain ML feature-store workloads',
         problem: (
-          <>
-            Aerospike fits the online feature store profile well —
-            sub-millisecond point reads, predictable tail latency, and
-            native list and map types for feature vectors. However, Python
-            is the primary language of ML pipelines, and the official
-            client is a CFFI binding to the C library: the GIL is held
-            across the I/O path, asynchronous I/O is not natively
-            supported, and the published type stubs are not kept in sync
-            with the runtime. At feature-store throughput levels, that
-            overhead is significant enough to exclude Aerospike from
-            workloads where it would otherwise be a strong fit.
-          </>
+          <ul>
+            <li>CFFI binding to the C client — the GIL is held across the entire I/O path.</li>
+            <li>Asynchronous I/O is not natively supported; the published type stubs drift from the runtime.</li>
+            <li>At feature-store throughput, the overhead excludes Aerospike from workloads where it would otherwise be a strong fit.</li>
+          </ul>
         ),
         solution: (
           <>
-            →&nbsp;<code>aerospike-py</code> — a client implemented from
-            the ground up in Rust&nbsp;(PyO3), with native asynchronous
-            I/O, GIL release across the entire I/O path, NumPy-aware
-            batch interfaces, and complete type stubs. Approximately{' '}
-            <strong>2.4× the throughput</strong> of the official C client
-            on standard mixed workloads, and first-class support for ML
-            inference servers.
+            →&nbsp;<code>aerospike-py</code> — Rust&nbsp;(PyO3) client with native
+            async, GIL release across the I/O path, and NumPy-aware batch
+            interfaces. Approximately <strong>2.4× the throughput</strong> of
+            the official C client on standard mixed workloads.
           </>
         ),
       },
@@ -75,26 +65,19 @@ const CONTENT: Record<Lang, Content> = {
         tag: '02 · Cloud-native gap',
         title: 'Aerospike CE has no community-maintained cloud-native ecosystem',
         problem: (
-          <>
-            Aerospike CE does not ship with a community-maintained
-            Kubernetes operator — the official AKO is restricted to the
-            Enterprise Edition. There is no maintained web management
-            interface, and most operational tooling is designed for
-            bare-metal deployments. Day-2 operations on Kubernetes —
-            scaling, rolling upgrades, warm restarts, dynamic
-            configuration changes — are left to each team to
-            reimplement.
-          </>
+          <ul>
+            <li>No community Kubernetes operator — the official AKO is Enterprise-only.</li>
+            <li>No maintained web management interface; most tooling assumes bare-metal deployments.</li>
+            <li>Day-2 operations (scaling, rolling upgrades, warm restarts, dynamic config) are left to each team to reimplement.</li>
+          </ul>
         ),
         solution: (
           <>
-            →&nbsp;<strong>ACKO</strong> (a CE-focused Kubernetes operator),{' '}
-            <strong>Cluster Manager</strong> (a FastAPI + Next.js management
-            interface), and <code>ackoctl</code> (a CLI). Declarative
-            cluster lifecycle management, rolling upgrades, warm-restart
-            workflows, ACL management, and an OpenTelemetry-instrumented
-            data path — all defined through CRDs and exposed via both UI
-            and CLI.
+            →&nbsp;<strong>ACKO</strong> (operator) +{' '}
+            <strong>Cluster Manager</strong> (UI) +{' '}
+            <code>ackoctl</code> (CLI). Declarative cluster lifecycle,
+            rolling upgrades, warm-restart workflows, ACL management, and
+            an OpenTelemetry-instrumented data path — all CRD-driven.
           </>
         ),
       },
@@ -102,24 +85,17 @@ const CONTENT: Record<Lang, Content> = {
         tag: '03 · License model',
         title: 'Enterprise Edition adoption is not an individual decision',
         problem: (
-          <>
-            Aerospike Enterprise Edition is licensed at the organization
-            level. Adoption requires a commercial agreement that involves
-            procurement, legal, finance, and architecture review — by
-            design, the decision sits above any individual engineer or
-            team. As a result, teams that would benefit from Enterprise
-            Edition features cannot adopt them on their own initiative,
-            and Community Edition becomes the practical production
-            baseline for those teams.
-          </>
+          <ul>
+            <li>Enterprise Edition is licensed at the organization level — adoption requires a commercial agreement.</li>
+            <li>Procurement, legal, finance, and architecture review are involved by design.</li>
+            <li>The decision sits above any individual engineer or team, so CE becomes the practical production baseline.</li>
+          </ul>
         ),
         solution: (
           <>
-            →&nbsp;Every component in this ecosystem supports both
-            Aerospike CE and the Enterprise Edition through a single,
-            consistent API. Teams can build and operate on CE today with
-            the same operator, client, and observability stack, and
-            migrate to EE if and when the organizational decision is
+            →&nbsp;Every component supports both <strong>CE and Enterprise
+            Edition</strong> through a single, consistent API. Build on CE
+            today, migrate to EE if and when the organizational decision is
             made — without changes to application code or operational
             tooling.
           </>
@@ -183,27 +159,18 @@ const CONTENT: Record<Lang, Content> = {
         tag: '01 · 클라이언트 성능',
         title: '공식 Python 클라이언트로는 ML feature store 워크로드를 감당하기 어렵다',
         problem: (
-          <>
-            Aerospike는 온라인 feature store의 요구 사항에 잘 부합한다 —
-            서브밀리세컨드 포인트 리드, 예측 가능한 tail latency, feature
-            vector에 적합한 list/map 네이티브 타입. 그러나 ML
-            파이프라인의 주 언어는 Python이며, 공식 클라이언트는 C
-            라이브러리에 대한 CFFI 바인딩으로 구현되어 있다. I/O 경로
-            전반에서 GIL이 유지되고, 비동기 I/O가 네이티브로 지원되지
-            않으며, 게시된 type stub은 런타임과 일치하지 않는다. feature
-            store 처리량 수준에서는 이 오버헤드가 충분히 커서, 본래
-            적합한 워크로드에서조차 Aerospike가 채택 후보에서 제외되는
-            결과로 이어진다.
-          </>
+          <ul>
+            <li>C 클라이언트에 대한 CFFI 바인딩 — I/O 경로 전반에서 GIL이 유지된다.</li>
+            <li>비동기 I/O가 네이티브로 지원되지 않고, 게시된 type stub은 런타임과 일치하지 않는다.</li>
+            <li>feature store 처리량 수준에서 본래 적합한 워크로드조차 Aerospike가 채택 후보에서 제외된다.</li>
+          </ul>
         ),
         solution: (
           <>
-            →&nbsp;<code>aerospike-py</code> — Rust(PyO3) 기반으로 처음
-            부터 다시 구현한 클라이언트. 네이티브 비동기 I/O, I/O 경로
-            전체에서 GIL release, NumPy 친화 배치 인터페이스, 완전한 type
-            stub을 제공한다. 표준 mixed 워크로드 기준으로 공식 C
-            클라이언트 대비 <strong>약 2.4배의 처리량</strong>을 보이며,
-            ML 추론 서버를 first-class로 지원한다.
+            →&nbsp;<code>aerospike-py</code> — Rust(PyO3) 기반 클라이언트.
+            네이티브 비동기 I/O, I/O 경로 GIL release, NumPy 친화 배치
+            인터페이스 제공. 표준 mixed 워크로드 기준 공식 C 클라이언트
+            대비 <strong>약 2.4배의 처리량</strong>.
           </>
         ),
       },
@@ -211,23 +178,19 @@ const CONTENT: Record<Lang, Content> = {
         tag: '02 · 클라우드 네이티브 갭',
         title: 'Aerospike CE에는 커뮤니티 수준의 cloud-native 생태계가 없다',
         problem: (
-          <>
-            Aerospike CE는 커뮤니티가 유지보수하는 쿠버네티스
-            오퍼레이터를 제공하지 않으며, 공식 AKO는 Enterprise Edition에
-            한정된다. 유지보수되는 웹 관리 인터페이스도 없고, 대부분의
-            운영 도구는 bare-metal 배포를 전제로 설계되어 있다. 쿠버네티스
-            위에서의 day-2 운영 — 스케일링, 롤링 업그레이드, warm restart,
-            동적 설정 변경 — 은 팀마다 개별적으로 다시 구현해야 한다.
-          </>
+          <ul>
+            <li>커뮤니티가 유지보수하는 쿠버네티스 오퍼레이터 없음 — 공식 AKO는 Enterprise Edition 전용.</li>
+            <li>유지보수되는 웹 관리 인터페이스 없음, 대부분의 운영 도구는 bare-metal 배포 전제.</li>
+            <li>스케일링·롤링 업그레이드·warm restart 등 day-2 운영을 팀마다 개별적으로 재구현해야 한다.</li>
+          </ul>
         ),
         solution: (
           <>
-            →&nbsp;<strong>ACKO</strong>(CE 전용 쿠버네티스 오퍼레이터),{' '}
-            <strong>Cluster Manager</strong>(FastAPI + Next.js 기반 관리
-            인터페이스), <code>ackoctl</code>(CLI). 선언적 클러스터
-            라이프사이클 관리, 롤링 업그레이드, warm-restart 워크플로우,
-            ACL 관리, OpenTelemetry로 계측된 데이터 경로 — 모두 CRD로
-            정의하고 UI와 CLI 양쪽에서 노출한다.
+            →&nbsp;<strong>ACKO</strong>(오퍼레이터) +{' '}
+            <strong>Cluster Manager</strong>(UI) +{' '}
+            <code>ackoctl</code>(CLI). 선언적 클러스터 라이프사이클, 롤링
+            업그레이드, warm-restart 워크플로우, ACL 관리, OpenTelemetry로
+            계측된 데이터 경로 — 모두 CRD 기반.
           </>
         ),
       },
@@ -235,23 +198,19 @@ const CONTENT: Record<Lang, Content> = {
         tag: '03 · 라이선스 모델',
         title: 'Enterprise Edition 도입은 개인 차원에서 결정할 수 있는 사안이 아니다',
         problem: (
-          <>
-            Aerospike Enterprise Edition은 조직 단위로 라이선스가
-            발급된다. 도입을 위해서는 구매·법무·재무·아키텍처 검토를
-            수반하는 상업 계약이 필요하며, 결정 권한은 설계상 개별
-            엔지니어나 팀의 범위를 벗어난다. 그 결과, EE 기능이 필요한
-            팀이라 하더라도 자체 판단으로 도입하기는 어렵고, 해당 팀에는
-            Community Edition이 실질적인 프로덕션 기준이 된다.
-          </>
+          <ul>
+            <li>Enterprise Edition은 조직 단위 라이선스 — 상업 계약이 필요하다.</li>
+            <li>구매·법무·재무·아키텍처 검토를 설계상 수반한다.</li>
+            <li>결정 권한이 개별 엔지니어나 팀의 범위를 벗어나, 해당 팀에는 CE가 실질적인 프로덕션 기준이 된다.</li>
+          </ul>
         ),
         solution: (
           <>
-            →&nbsp;이 ecosystem의 모든 컴포넌트는 단일하고 일관된 API를
-            통해 Aerospike CE와 Enterprise Edition을 동시에 지원한다.
-            동일한 오퍼레이터, 클라이언트, observability 스택을 그대로
-            사용하면서 오늘은 CE로 구축·운영하고, 조직 차원의 결정이
-            이루어지는 시점에 EE로 이전한다 — 애플리케이션 코드나 운영
-            도구의 변경 없이.
+            →&nbsp;모든 컴포넌트가 단일하고 일관된 API를 통해{' '}
+            <strong>CE와 Enterprise Edition을 동시에 지원</strong>한다.
+            오늘은 CE로 구축·운영하고, 조직 차원의 결정이 이루어지는
+            시점에 EE로 이전한다 — 애플리케이션 코드나 운영 도구의 변경
+            없이.
           </>
         ),
       },
@@ -341,7 +300,7 @@ export default function WhySection(): React.JSX.Element {
           <article key={p.tag} className={styles.problemCard}>
             <div className={styles.problemTag}>{p.tag}</div>
             <h3 className={styles.problemTitle}>{p.title}</h3>
-            <p className={styles.problemBody}>{p.problem}</p>
+            <div className={styles.problemBody}>{p.problem}</div>
             <p className={styles.problemSolution}>{p.solution}</p>
           </article>
         ))}

--- a/docs/src/components/WhySection/index.tsx
+++ b/docs/src/components/WhySection/index.tsx
@@ -28,93 +28,100 @@ interface Content {
 const CONTENT: Record<Lang, Content> = {
   en: {
     eyebrow: 'Why this ecosystem exists',
-    title: 'Production-grade fundamentals, an incomplete adoption surface',
+    title: 'Project overview',
     lead: (
       <>
-        Aerospike is a high-performance, low-latency NoSQL database with strong
-        fit for online feature stores and other low-latency serving paths.
-        However, three structural gaps make production adoption difficult
-        today — particularly in large organizations and on Kubernetes. The{' '}
-        <strong>aerospike-ce-ecosystem</strong> addresses these gaps with an
-        open-source, cloud-native, agent-friendly toolchain.
+        Aerospike is a high-performance, low-latency NoSQL database and a
+        natural fit for online feature stores and other low-latency
+        serving paths. In real-world production environments, however,
+        three structural constraints come into play — particularly in
+        large organizations and on Kubernetes. The{' '}
+        <strong>aerospike-ce-ecosystem</strong> exists to address those
+        constraints with an open-source, cloud-native, agent-friendly
+        toolchain.
       </>
     ),
     problems: [
       {
         tag: '01 · Client performance',
-        title: 'The upstream Python client cannot sustain ML feature-store workloads',
+        title: 'The official Python client cannot sustain ML feature-store workloads',
         problem: (
           <>
-            Aerospike maps cleanly to the online feature store profile —
-            sub-millisecond point reads, predictable tail latency, and native
-            list/map types for feature vectors. However, Python is the primary
-            language of ML pipelines, and the upstream client is a CFFI binding
-            to the C library: the GIL is held across the I/O path, asynchronous
-            I/O is not natively supported, and the published type stubs are not
-            kept in sync with the runtime. At feature-store throughput, the
-            resulting overhead is significant enough to exclude Aerospike from
+            Aerospike fits the online feature store profile well —
+            sub-millisecond point reads, predictable tail latency, and
+            native list and map types for feature vectors. However, Python
+            is the primary language of ML pipelines, and the official
+            client is a CFFI binding to the C library: the GIL is held
+            across the I/O path, asynchronous I/O is not natively
+            supported, and the published type stubs are not kept in sync
+            with the runtime. At feature-store throughput levels, that
+            overhead is significant enough to exclude Aerospike from
             workloads where it would otherwise be a strong fit.
           </>
         ),
         solution: (
           <>
-            →&nbsp;<code>aerospike-py</code> — a client implemented from the
-            ground up in Rust&nbsp;(PyO3), exposing native asynchronous I/O,
-            GIL release across the entire I/O path, NumPy-aware batch
-            interfaces, and complete type stubs. Approximately{' '}
-            <strong>2.4× the throughput</strong> of the upstream C client on
-            standard mixed workloads, with first-class support for ML
+            →&nbsp;<code>aerospike-py</code> — a client implemented from
+            the ground up in Rust&nbsp;(PyO3), with native asynchronous
+            I/O, GIL release across the entire I/O path, NumPy-aware
+            batch interfaces, and complete type stubs. Approximately{' '}
+            <strong>2.4× the throughput</strong> of the official C client
+            on standard mixed workloads, and first-class support for ML
             inference servers.
           </>
         ),
       },
       {
         tag: '02 · Cloud-native gap',
-        title: 'Aerospike CE has no community Kubernetes story',
+        title: 'Aerospike CE has no community-maintained cloud-native ecosystem',
         problem: (
           <>
-            Aerospike CE does not ship with a community-maintained Kubernetes
-            operator — the upstream AKO is restricted to the Enterprise
-            Edition. There is no maintained web management interface, and
-            most operational tooling is designed for bare-metal deployments.
-            Day-2 operations on Kubernetes — scaling, rolling upgrades,
-            warm restarts, dynamic configuration changes — must be
-            implemented independently by each team.
+            Aerospike CE does not ship with a community-maintained
+            Kubernetes operator — the official AKO is restricted to the
+            Enterprise Edition. There is no maintained web management
+            interface, and most operational tooling is designed for
+            bare-metal deployments. Day-2 operations on Kubernetes —
+            scaling, rolling upgrades, warm restarts, dynamic
+            configuration changes — are left to each team to
+            reimplement.
           </>
         ),
         solution: (
           <>
             →&nbsp;<strong>ACKO</strong> (a CE-focused Kubernetes operator),{' '}
             <strong>Cluster Manager</strong> (a FastAPI + Next.js management
-            interface), and <code>ackoctl</code> (a CLI surface). Declarative
+            interface), and <code>ackoctl</code> (a CLI). Declarative
             cluster lifecycle management, rolling upgrades, warm-restart
-            workflows, ACL management, and an OpenTelemetry-instrumented data
-            path — all defined through CRDs and exposed via both UI and CLI.
+            workflows, ACL management, and an OpenTelemetry-instrumented
+            data path — all defined through CRDs and exposed via both UI
+            and CLI.
           </>
         ),
       },
       {
         tag: '03 · License model',
-        title: 'Enterprise Edition adoption is not an individual-level decision',
+        title: 'Enterprise Edition adoption is not an individual decision',
         problem: (
           <>
             Aerospike Enterprise Edition is licensed at the organization
             level. Adoption requires a commercial agreement that involves
-            procurement, legal, finance, and architecture review — by design,
-            the decision sits above the individual engineer or team. As a
-            result, teams that would benefit from Enterprise Edition features
-            cannot adopt them on their own initiative, and Community Edition
-            becomes the practical production baseline for those teams.
+            procurement, legal, finance, and architecture review — by
+            design, the decision sits above any individual engineer or
+            team. As a result, teams that would benefit from Enterprise
+            Edition features cannot adopt them on their own initiative,
+            and Community Edition becomes the practical production
+            baseline for those teams.
           </>
         ),
         solution: (
           <>
-            →&nbsp;Every component in this ecosystem supports both Aerospike
-            CE and the Enterprise Edition through a single, stable surface.
-            Teams can build and operate on CE today with the same operator,
-            client, and observability stack, and migrate to EE if and when
-            the organizational decision is made — without changes to
-            application integration code or operational tooling.
+            →&nbsp;Every component in this ecosystem supports both
+            Aerospike CE and the Enterprise Edition through a single,
+            consistent API. Teams can build and operate on CE today with
+            the same operator, client, and observability stack, and
+            migrate to EE if and when the organizational decision is
+            made — without changes to application code or operational
+            tooling.
           </>
         ),
       },
@@ -122,24 +129,25 @@ const CONTENT: Record<Lang, Content> = {
     commitmentsTitle: 'What we ship',
     commitments: [
       {
-        title: 'Open-source first, Enterprise-Edition compatible',
+        title: 'Supports CE & EE',
         body: (
           <>
             Every component operates against both Aerospike CE and the
-            Enterprise Edition. Adoption is not gated on the procurement
-            timeline — CE today, EE later, with no integration changes
-            required.
+            Enterprise Edition through a single, consistent API. Adoption
+            is not tied to the procurement timeline — CE today, EE later,
+            with no integration changes.
           </>
         ),
       },
       {
-        title: 'Cloud-native by default',
+        title: 'Cloud-native advancement',
         body: (
           <>
-            Declarative Kubernetes management via ACKO, a maintained web
-            management interface for cluster operations, and an
-            OpenTelemetry-instrumented data path — without an Enterprise
-            Edition license.
+            We continuously advance the cloud-native story for Aerospike
+            CE — ACKO for declarative Kubernetes management, a maintained
+            web management interface for cluster operations, and an
+            OpenTelemetry-instrumented data path. None of these require
+            an Enterprise Edition license.
           </>
         ),
       },
@@ -159,63 +167,64 @@ const CONTENT: Record<Lang, Content> = {
 
   ko: {
     eyebrow: '이 ecosystem이 존재하는 이유',
-    title: '견고한 기반, 미완성된 도입 표면',
+    title: '프로젝트 개요',
     lead: (
       <>
-        Aerospike는 고성능·저지연 NoSQL 데이터베이스로, 온라인 피처
-        스토어를 비롯한 저지연 서빙 경로에 적합한 특성을 가진다. 그러나
-        실제 운영 환경에서의 도입을 가로막는 세 가지 구조적 갭이 존재한다
-        — 특히 대규모 조직과 쿠버네티스 환경에서 두드러진다.{' '}
+        Aerospike는 고성능·저지연 NoSQL 데이터베이스로, 온라인 feature
+        store를 비롯한 저지연 서빙 경로에 자연스럽게 들어맞는다. 그러나
+        실제 운영 환경에는 세 가지 구조적 제약이 존재한다 — 특히
+        대규모 조직과 쿠버네티스 환경에서 두드러진다.{' '}
         <strong>aerospike-ce-ecosystem</strong>은 오픈소스 · 클라우드
-        네이티브 · 에이전트 친화적 도구를 통해 이 갭을 해소한다.
+        네이티브 · 에이전트 친화적인 도구로 이 제약을 해소한다.
       </>
     ),
     problems: [
       {
         tag: '01 · 클라이언트 성능',
-        title: '업스트림 Python 클라이언트로는 ML 피처 스토어 워크로드를 감당하기 어렵다',
+        title: '공식 Python 클라이언트로는 ML feature store 워크로드를 감당하기 어렵다',
         problem: (
           <>
-            Aerospike는 온라인 피처 스토어의 요구 사항에 잘 부합한다 —
-            서브밀리세컨드 포인트 리드, 예측 가능한 tail latency, 피처
-            벡터에 적합한 list/map 네이티브 타입. 그러나 ML 파이프라인의
-            주 언어는 Python이며, 업스트림 클라이언트는 C 라이브러리에
-            대한 CFFI 바인딩으로 구현되어 있다. I/O 경로 전반에서 GIL이
-            유지되고, 비동기 I/O가 네이티브로 지원되지 않으며, 게시된
-            type stub은 런타임과 일치하지 않는다. 피처 스토어 처리량
-            수준에서는 이 오버헤드가 충분히 커서, fit이 좋은 워크로드에서
-            조차 Aerospike가 채택 후보에서 제외되는 결과로 이어진다.
+            Aerospike는 온라인 feature store의 요구 사항에 잘 부합한다 —
+            서브밀리세컨드 포인트 리드, 예측 가능한 tail latency, feature
+            vector에 적합한 list/map 네이티브 타입. 그러나 ML
+            파이프라인의 주 언어는 Python이며, 공식 클라이언트는 C
+            라이브러리에 대한 CFFI 바인딩으로 구현되어 있다. I/O 경로
+            전반에서 GIL이 유지되고, 비동기 I/O가 네이티브로 지원되지
+            않으며, 게시된 type stub은 런타임과 일치하지 않는다. feature
+            store 처리량 수준에서는 이 오버헤드가 충분히 커서, 본래
+            적합한 워크로드에서조차 Aerospike가 채택 후보에서 제외되는
+            결과로 이어진다.
           </>
         ),
         solution: (
           <>
-            →&nbsp;<code>aerospike-py</code> — Rust(PyO3) 기반으로 처음부터
-            다시 구현한 클라이언트. 네이티브 비동기 I/O, I/O 경로 전체에서의
-            GIL release, NumPy 인지 배치 인터페이스, 완전한 type stub을
-            제공한다. 표준 mixed 워크로드 기준으로 업스트림 C 클라이언트
-            대비 <strong>약 2.4배의 처리량</strong>을 보이며, ML 추론
-            서버를 1급으로 지원한다.
+            →&nbsp;<code>aerospike-py</code> — Rust(PyO3) 기반으로 처음
+            부터 다시 구현한 클라이언트. 네이티브 비동기 I/O, I/O 경로
+            전체에서 GIL release, NumPy 친화 배치 인터페이스, 완전한 type
+            stub을 제공한다. 표준 mixed 워크로드 기준으로 공식 C
+            클라이언트 대비 <strong>약 2.4배의 처리량</strong>을 보이며,
+            ML 추론 서버를 first-class로 지원한다.
           </>
         ),
       },
       {
         tag: '02 · 클라우드 네이티브 갭',
-        title: 'Aerospike CE에는 커뮤니티 수준의 쿠버네티스 스토리가 없다',
+        title: 'Aerospike CE에는 커뮤니티 수준의 cloud-native 생태계가 없다',
         problem: (
           <>
-            Aerospike CE는 커뮤니티가 유지보수하는 쿠버네티스 오퍼레이터를
-            제공하지 않으며, 업스트림 AKO는 Enterprise Edition에만
+            Aerospike CE는 커뮤니티가 유지보수하는 쿠버네티스
+            오퍼레이터를 제공하지 않으며, 공식 AKO는 Enterprise Edition에
             한정된다. 유지보수되는 웹 관리 인터페이스도 없고, 대부분의
             운영 도구는 bare-metal 배포를 전제로 설계되어 있다. 쿠버네티스
             위에서의 day-2 운영 — 스케일링, 롤링 업그레이드, warm restart,
-            동적 설정 변경 등 — 은 팀마다 개별적으로 구현해야 한다.
+            동적 설정 변경 — 은 팀마다 개별적으로 다시 구현해야 한다.
           </>
         ),
         solution: (
           <>
             →&nbsp;<strong>ACKO</strong>(CE 전용 쿠버네티스 오퍼레이터),{' '}
             <strong>Cluster Manager</strong>(FastAPI + Next.js 기반 관리
-            인터페이스), <code>ackoctl</code>(CLI 표면). 선언적 클러스터
+            인터페이스), <code>ackoctl</code>(CLI). 선언적 클러스터
             라이프사이클 관리, 롤링 업그레이드, warm-restart 워크플로우,
             ACL 관리, OpenTelemetry로 계측된 데이터 경로 — 모두 CRD로
             정의하고 UI와 CLI 양쪽에서 노출한다.
@@ -230,20 +239,19 @@ const CONTENT: Record<Lang, Content> = {
             Aerospike Enterprise Edition은 조직 단위로 라이선스가
             발급된다. 도입을 위해서는 구매·법무·재무·아키텍처 검토를
             수반하는 상업 계약이 필요하며, 결정 권한은 설계상 개별
-            엔지니어나 팀의 범위를 벗어난다. 그 결과, EE 기능의 이점을
-            누릴 수 있는 팀이라 하더라도 자체 판단으로 도입하기는 어렵고,
-            해당 팀에는 Community Edition이 실질적인 프로덕션 기준이
-            된다.
+            엔지니어나 팀의 범위를 벗어난다. 그 결과, EE 기능이 필요한
+            팀이라 하더라도 자체 판단으로 도입하기는 어렵고, 해당 팀에는
+            Community Edition이 실질적인 프로덕션 기준이 된다.
           </>
         ),
         solution: (
           <>
-            →&nbsp;이 ecosystem의 모든 컴포넌트는 단일한 안정 표면을 통해
-            Aerospike CE와 Enterprise Edition을 동시에 지원한다. 동일한
-            오퍼레이터, 클라이언트, observability 스택을 그대로 사용하면서
-            오늘은 CE로 구축·운영하고, 조직 차원의 결정이 이루어지는
-            시점에 EE로 이전한다 — 애플리케이션 통합 코드나 운영 도구의
-            변경 없이.
+            →&nbsp;이 ecosystem의 모든 컴포넌트는 단일하고 일관된 API를
+            통해 Aerospike CE와 Enterprise Edition을 동시에 지원한다.
+            동일한 오퍼레이터, 클라이언트, observability 스택을 그대로
+            사용하면서 오늘은 CE로 구축·운영하고, 조직 차원의 결정이
+            이루어지는 시점에 EE로 이전한다 — 애플리케이션 코드나 운영
+            도구의 변경 없이.
           </>
         ),
       },
@@ -251,17 +259,17 @@ const CONTENT: Record<Lang, Content> = {
     commitmentsTitle: 'What we ship',
     commitments: [
       {
-        title: '오픈소스 우선, Enterprise Edition 호환',
+        title: 'Support CE & EE',
         body: (
           <>
-            모든 컴포넌트가 Aerospike CE와 Enterprise Edition 양쪽에서
-            동작한다. 도입이 구매 절차의 일정에 묶이지 않는다 — 오늘은
-            CE, 추후 EE, 통합 코드 변경 없이.
+            모든 컴포넌트가 단일하고 일관된 API를 통해 Aerospike CE와
+            Enterprise Edition 양쪽에서 동작한다. 도입이 구매 절차의 일정에
+            묶이지 않는다 — 오늘은 CE, 추후 EE, 통합 코드 변경 없이.
           </>
         ),
       },
       {
-        title: '클라우드 네이티브 우선',
+        title: 'Cloud-native by default',
         body: (
           <>
             ACKO를 통한 선언적 쿠버네티스 관리, 유지보수되는 클러스터
@@ -271,13 +279,13 @@ const CONTENT: Record<Lang, Content> = {
         ),
       },
       {
-        title: '에이전트 주도 운영',
+        title: 'Agent-driven operations',
         body: (
           <>
             동일한 운영 primitive를 <code>ackoctl</code>과 Claude Code
-            플러그인 팩을 통해 노출한다. 자율 에이전트는 사람 운영자와
-            동일한 표면에서 Aerospike 클러스터를 provisioning · 스케일링 ·
-            디버깅 · 운영할 수 있다.
+            플러그인 팩을 통해 노출한다. 자율 에이전트는 운영자와 동일한
+            표면에서 Aerospike 클러스터를 프로비저닝 · 스케일링 · 디버깅 ·
+            운영할 수 있다.
           </>
         ),
       },

--- a/docs/src/components/WhySection/styles.module.css
+++ b/docs/src/components/WhySection/styles.module.css
@@ -133,9 +133,23 @@
 .problemBody {
   margin: 0 0 14px;
   font-size: 13.5px;
-  line-height: 1.65;
+  line-height: 1.6;
   color: var(--ifm-color-emphasis-700);
   flex-grow: 1;
+}
+.problemBody ul {
+  margin: 0;
+  padding-left: 18px;
+  list-style: disc;
+}
+.problemBody li {
+  margin-bottom: 6px;
+}
+.problemBody li:last-child {
+  margin-bottom: 0;
+}
+.problemBody li::marker {
+  color: var(--ifm-color-emphasis-500);
 }
 .problemSolution {
   margin: 0;


### PR DESCRIPTION
## Summary

Comprehensive copy cleanup across the home-page WhySection and the canonical project-goals.md after several rounds of maintainer-tone feedback.

## Title

Both languages drop the awkward two-clause framing:

- EN: "Production-grade fundamentals, an incomplete adoption surface" → **"Project overview"**
- KO: "견고한 기반, 미완성된 도입 표면" → **"프로젝트 개요"**

The eyebrow (\`Why this ecosystem exists\` / \`이 ecosystem이 존재하는 이유\`) already supplies the framing — the title doesn't need to repeat it.

## Terminology

- \`upstream\` Python/C client → \`official\` Python/C client. The Aerospike-published clients are not upstream of aerospike-py in any meaningful sense; they are simply the official ones we improve on. Same for AKO. (\`aerospike-client-rust\` stays "upstream" because aerospike-py genuinely *is* a downstream consumer of that crate.)
- "CLI surface" / "stable surface" jargon dropped — just "CLI", just "API".
- KO: \`피처 스토어\` / \`피처 벡터\` → \`feature store\` / \`feature vector\`. These are established loanwords in Korean ML / data engineering.

## Commitments

- "Open-source first, EE compatible" → **"Supports CE & EE"** — three words, no contortions.
- "Cloud-native by default" → **"Cloud-native advancement"** — the commitment is to *advance* the cloud-native story, not merely default to it. Body copy updated accordingly.

## Tone

- KO lead: \`도입을 가로막는\` → \`구조적 제약이 존재한다\`. Described as a constraint that exists, not as an active obstacle being put in someone's way.
- Problem-3 body softened in both languages — no \`bell-the-cat\` idiom, no "no one owns pushing the contract through" language. Just the factual constraint: EE adoption is by design not an individual-level decision.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm run build\` — no broken links, no new warnings
- [x] Visual check: tab switch instant, layout reflow at narrow viewports