### PR TITLE
docs: drop CE qualifier from cloud-native gap framing

### DIFF
--- a/docs/docs/goals/project-goals.md
+++ b/docs/docs/goals/project-goals.md
@@ -50,9 +50,9 @@ I/O path, NumPy-aware batch interfaces, and complete `.pyi` stubs.
 Approximately **2.4× the throughput** of the official C client on standard
 mixed workloads.
 
-### 2. Aerospike CE has no community-maintained cloud-native ecosystem
+### 2. Aerospike has no community-maintained cloud-native ecosystem
 
-Aerospike CE does not ship with a community-maintained Kubernetes operator
+Aerospike does not ship with a community-maintained Kubernetes operator
 — the official AKO is restricted to the Enterprise Edition. There is no
 maintained web management interface, and most operational tooling is
 designed for bare-metal deployments. Day-2 operations on Kubernetes —

--- a/docs/src/components/WhySection/index.tsx
+++ b/docs/src/components/WhySection/index.tsx
@@ -63,7 +63,7 @@ const CONTENT: Record<Lang, Content> = {
       },
       {
         tag: '02 · Cloud-native gap',
-        title: 'Aerospike CE has no community-maintained cloud-native ecosystem',
+        title: 'Aerospike has no community-maintained cloud-native ecosystem',
         problem: (
           <ul>
             <li>No community Kubernetes operator — the official AKO is Enterprise-only.</li>
@@ -176,7 +176,7 @@ const CONTENT: Record<Lang, Content> = {
       },
       {
         tag: '02 · 클라우드 네이티브 갭',
-        title: 'Aerospike CE에는 커뮤니티 수준의 cloud-native 생태계가 없다',
+        title: 'Aerospike에는 커뮤니티 수준의 cloud-native 생태계가 없다',
         problem: (
           <ul>
             <li>커뮤니티가 유지보수하는 쿠버네티스 오퍼레이터 없음 — 공식 AKO는 Enterprise Edition 전용.</li>


### PR DESCRIPTION
Small cleanup. `Aerospike CE has no community-maintained cloud-native ecosystem` implied the gap is CE-specific. It isn't — AKO is Enterprise-only and the community side has no operator either way. Just `Aerospike` is cleaner and equally accurate (the next sentence still calls out AKO being EE-restricted).