### PR TITLE
docs: add ADR-0052 to index and fix two absolute ADR links

### DIFF
--- a/docs/docs/architecture/adr-index.mdx
+++ b/docs/docs/architecture/adr-index.mdx
@@ -120,6 +120,7 @@ Architecture Decision Record(ADR)는 프로젝트의 중요한 아키텍처 결�
 | [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
 | [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
 | [ADR-0051](./adr/2026-04-07-daily-release-pipeline.md) | 에코시스템 일일 자동 릴리스 파이프라인 | 2026-04-07 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
+| [ADR-0052](./adr/2026-05-23-aerospike-py-batch-read-profiling.md) | aerospike-py batch_read 병목 프로파일링 — 3-Methodology Cross-Validation | 2026-05-23 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> |
 
   </TabItem>
   <TabItem value="aerospike-py" label="aerospike-py">
@@ -145,6 +146,7 @@ Architecture Decision Record(ADR)는 프로젝트의 중요한 아키텍처 결�
 | [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Proposed" /> |
 | [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Proposed" /> |
 | [ADR-0051](./adr/2026-04-07-daily-release-pipeline.md) | 에코시스템 일일 자동 릴리스 파이프라인 | 2026-04-07 | <Status status="Accepted" /> |
+| [ADR-0052](./adr/2026-05-23-aerospike-py-batch-read-profiling.md) | aerospike-py batch_read 병목 프로파일링 | 2026-05-23 | <Status status="Accepted" /> |
 
   </TabItem>
   <TabItem value="acko" label="ACKO">

--- a/docs/docs/history/decisions/2026-03.md
+++ b/docs/docs/history/decisions/2026-03.md
@@ -57,7 +57,7 @@ Aerospike CE Ecosystem에서 2026년 3월에 내린 주요 의사결정을 기�
 - **배경**: DaisyUI의 opinionated 스타일이 커스텀 디자인 시스템 구축에 제약
 - **근거**: Tailwind CSS 4의 유틸리티 퍼스트 접근 + Radix UI의 접근성 기반 헤드리스 컴포넌트로 더 유연한 디자인 가능
 - **영향**: PR #153, 14개 Radix-based primitive 컴포넌트 자체 구축
-- **참조**: [ADR-0005: DaisyUI Removal](/docs/architecture/adr/2026-02-25-daisyui-removal)
+- **참조**: [ADR-0005: DaisyUI Removal](../../architecture/adr/2026-02-25-daisyui-removal.md)
 
 ---
 
@@ -67,7 +67,7 @@ Aerospike CE Ecosystem에서 2026년 3월에 내린 주요 의사결정을 기�
 
 - **배경**: batch_read, batch_write, batch_operate의 반환 타입이 제각각이어서 사용성 저하
 - **근거**: per-record result_code + succeeded/failed 카운트로 일관된 에러 처리 가능
-- **참조**: [ADR-0009: Unified BatchRecords API](/docs/architecture/adr/2026-03-20-unified-batch-records-api), PR #239
+- **참조**: [ADR-0009: Unified BatchRecords API](../../architecture/adr/2026-03-20-unified-batch-records-api.md), PR #239
 
 ---
 


### PR DESCRIPTION
## Summary

- **Add ADR-0052 to adr-index.mdx** — the ADR file (`2026-05-23-aerospike-py-batch-read-profiling.md`) exists at sidebar_position 52 and has been merged into `main`, but the navigation index stopped at ADR-0051 in both the "전체" (all) tab and the "aerospike-py" tab. Users browsing the index could not discover or navigate to the latest ADR.
- **Fix two absolute `/docs/architecture/...` ADR links** in `history/decisions/2026-03.md` (lines 60 and 70). The site is served from `baseUrl: /project-hub/`, so absolute `/docs/...` URLs resolve to `/docs/...` (a 404 on the production site) instead of `/project-hub/docs/...`. Replaced both with relative `../../architecture/adr/...md` paths, matching every other ADR cross-reference in the decisions log.

## Verification

- `npm run build` succeeds locally with `onBrokenLinks: 'throw'` and `onBrokenMarkdownLinks: 'throw'` already configured in `docusaurus.config.ts`.
- The two replaced links resolve correctly to the existing ADR files.

## Test plan

- [x] `npm run build` passes (verified locally)
- [ ] Preview deployment renders ADR-0052 in both tabs
- [ ] Both decision-log links navigate to the correct ADR pages