### PR TITLE
docs(adr): align 2026-03-30 ADR title/H1 numbers with sidebar_position

### DIFF
--- a/docs/docs/architecture/adr/2026-03-30-asyncclient-connect-leak.md
+++ b/docs/docs/architecture/adr/2026-03-30-asyncclient-connect-leak.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0020: aerospike-py AsyncClient 동시 connect() 호출 시 연결 누수 방지 및 lifecycle 안전성 강화"
+title: "ADR-0029: aerospike-py AsyncClient 동시 connect() 호출 시 연결 누수 방지 및 lifecycle 안전성 강화"
 description: aerospike-py AsyncClient에서 동시 connect() 호출 시 발생하는 연결 누수를 AtomicBool guard와 상태 머신으로 방지하고, close() 후 재연결 시 전체 상태를 초기화하는 아키텍처 결정.
 sidebar_position: 29
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, aerospike-py, async, connection-safety, lifecycle, concurrency]
 last_updated: 2026-03-30
 ---
 
-# ADR-0020: aerospike-py AsyncClient 동시 connect() 호출 시 연결 누수 방지 및 lifecycle 안전성 강화
+# ADR-0029: aerospike-py AsyncClient 동시 connect() 호출 시 연결 누수 방지 및 lifecycle 안전성 강화
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-auth-security-headers.md
+++ b/docs/docs/architecture/adr/2026-03-30-auth-security-headers.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0020: Cluster Manager API 인증/인가 아키텍처 및 보안 헤더 강화"
+title: "ADR-0030: Cluster Manager API 인증/인가 아키텍처 및 보안 헤더 강화"
 description: Cluster Manager API에 JWT 기반 인증/인가(RBAC)를 도입하고 보안 헤더(HSTS, CORS 검증)를 강화하여 프로덕션 배포 가능성을 확보하는 아키텍처 결정.
 sidebar_position: 30
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, security, authentication, authorization, rbac, jwt, cors, hsts]
 last_updated: 2026-03-30
 ---
 
-# ADR-0020: Cluster Manager API 인증/인가 아키텍처 및 보안 헤더 강화
+# ADR-0030: Cluster Manager API 인증/인가 아키텍처 및 보안 헤더 강화
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-circuit-breaker-adaptive-threshold.md
+++ b/docs/docs/architecture/adr/2026-03-30-circuit-breaker-adaptive-threshold.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0017: ACKO Reconciliation Circuit Breaker 임계값 자동 조정 메커니즘"
+title: "ADR-0018: ACKO Reconciliation Circuit Breaker 임계값 자동 조정 메커니즘"
 description: ACKO의 reconciliation circuit breaker 고정 임계값을 에러 유형별 차등 임계값으로 개선하는 제안에 대한 검토 결과. 운영 데이터 부재로 보류.
 sidebar_position: 18
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, acko, kubernetes, reconciliation, circuit-breaker, adaptive-threshol
 last_updated: 2026-03-30
 ---
 
-# ADR-0017: ACKO Reconciliation Circuit Breaker 임계값 자동 조정 메커니즘
+# ADR-0018: ACKO Reconciliation Circuit Breaker 임계값 자동 조정 메커니즘
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-clientmanager-per-connection-lock.md
+++ b/docs/docs/architecture/adr/2026-03-30-clientmanager-per-connection-lock.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0020: Cluster Manager ClientManager 동시성 결함 분석 및 per-connection lock 도입"
+title: "ADR-0031: Cluster Manager ClientManager 동시성 결함 분석 및 per-connection lock 도입"
 description: ClientManager의 double-checked locking race condition을 per-connection-id AsyncLock으로 해결하고, string 기반 에러 감지를 구조화된 result_code 기반으로 전환하는 아키텍처 결정.
 sidebar_position: 31
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, concurrency, connection-management, error-handling, cluster-manager]
 last_updated: 2026-03-30
 ---
 
-# ADR-0020: Cluster Manager ClientManager 동시성 결함 분석 및 per-connection lock 도입
+# ADR-0031: Cluster Manager ClientManager 동시성 결함 분석 및 per-connection lock 도입
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-codegen-type-sync.md
+++ b/docs/docs/architecture/adr/2026-03-30-codegen-type-sync.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0017: Cluster Manager Backend↔Frontend 타입 동기화 자동화 (Codegen)"
+title: "ADR-0019: Cluster Manager Backend↔Frontend 타입 동기화 자동화 (Codegen)"
 description: Cluster Manager에서 FastAPI OpenAPI 스키마를 기반으로 TypeScript 타입을 자동 생성하여 Backend↔Frontend 타입 동기화를 자동화하는 아키텍처 결정.
 sidebar_position: 19
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, codegen, openapi, typescript, cluster-manager, type-safety]
 last_updated: 2026-03-30
 ---
 
-# ADR-0017: Cluster Manager Backend↔Frontend 타입 동기화 자동화 (Codegen)
+# ADR-0019: Cluster Manager Backend↔Frontend 타입 동기화 자동화 (Codegen)
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-dynamic-config-transaction.md
+++ b/docs/docs/architecture/adr/2026-03-30-dynamic-config-transaction.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0020: ACKO Dynamic Config 부분 적용 방지를 위한 트랜잭션 보장 전략"
+title: "ADR-0032: ACKO Dynamic Config 부분 적용 방지를 위한 트랜잭션 보장 전략"
 description: ACKO의 동적 설정 변경 시 부분 적용을 방지하기 위해 Two-Phase Commit 패턴과 ConfigDegraded 상태 전환을 도입하는 전략
 sidebar_position: 32
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, acko, dynamic-config, reconciliation, transaction, stabilization]
 last_updated: 2026-03-30
 ---
 
-# ADR-0020: ACKO Dynamic Config 부분 적용 방지를 위한 트랜잭션 보장 전략
+# ADR-0032: ACKO Dynamic Config 부분 적용 방지를 위한 트랜잭션 보장 전략
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-frontend-resource-leak-prevention.md
+++ b/docs/docs/architecture/adr/2026-03-30-frontend-resource-leak-prevention.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0020: Cluster Manager Frontend 리소스 누수 방지 및 API 호출 최적화"
+title: "ADR-0033: Cluster Manager Frontend 리소스 누수 방지 및 API 호출 최적화"
 description: Cluster Manager 프론트엔드에서 폴링 메모리 누수, AbortController 미사용, 상태 초기화 누락, 에러 정보 미노출 문제를 해결하는 표준 패턴 도입.
 sidebar_position: 33
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, performance, frontend, cluster-manager, resource-management, optimiz
 last_updated: 2026-03-30
 ---
 
-# ADR-0020: Cluster Manager Frontend 리소스 누수 방지 및 API 호출 최적화
+# ADR-0033: Cluster Manager Frontend 리소스 누수 방지 및 API 호출 최적화
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-graceful-cancellation.md
+++ b/docs/docs/architecture/adr/2026-03-30-graceful-cancellation.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0018: Cluster Manager Backend 비동기 연산의 Graceful Cancellation 전략"
+title: "ADR-0021: Cluster Manager Backend 비동기 연산의 Graceful Cancellation 전략"
 description: Cluster Manager Backend에서 클라이언트 연결 끊김 시 장시간 실행 중인 비동기 연산(scan, query, K8s API)을 Graceful하게 취소하는 전략 도입.
 sidebar_position: 21
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, cluster-manager, fastapi, cancellation, async, resource-management]
 last_updated: 2026-03-30
 ---
 
-# ADR-0018: Cluster Manager Backend 비동기 연산의 Graceful Cancellation 전략
+# ADR-0021: Cluster Manager Backend 비동기 연산의 Graceful Cancellation 전략
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-health-check-parallel.md
+++ b/docs/docs/architecture/adr/2026-03-30-health-check-parallel.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0020: Cluster Manager Health Check 병렬화 및 연결 실패 컨텍스트 전파"
+title: "ADR-0034: Cluster Manager Health Check 병렬화 및 연결 실패 컨텍스트 전파"
 description: Cluster Manager 초기 로딩 시 순차 health check를 병렬화하고, 연결 실패 시 에러 유형을 UI에 표시하여 디버깅 편의성을 개선
 sidebar_position: 34
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, cluster-manager, health-check, performance, ux]
 last_updated: 2026-03-30
 ---
 
-# ADR-0020: Cluster Manager Health Check 병렬화 및 연결 실패 컨텍스트 전파
+# ADR-0034: Cluster Manager Health Check 병렬화 및 연결 실패 컨텍스트 전파
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-info-batch-aggregation.md
+++ b/docs/docs/architecture/adr/2026-03-30-info-batch-aggregation.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0019: Cluster Manager Aerospike Info 명령 배치 집계로 클러스터 Overview 응답 시간 단축"
+title: "ADR-0025: Cluster Manager Aerospike Info 명령 배치 집계로 클러스터 Overview 응답 시간 단축"
 description: Cluster Manager에서 개별 Aerospike info 호출을 세미콜론 구분자 기반 배치 호출로 통합하고 TTL 캐시를 도입하여 클러스터 Overview 응답 시간을 75% 단축하는 아키텍처 결정.
 sidebar_position: 25
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, performance, cluster-manager, caching, aerospike-info]
 last_updated: 2026-03-30
 ---
 
-# ADR-0019: Cluster Manager Aerospike Info 명령 배치 집계로 클러스터 Overview 응답 시간 단축
+# ADR-0025: Cluster Manager Aerospike Info 명령 배치 집계로 클러스터 Overview 응답 시간 단축
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-k8s-server-side-pagination.md
+++ b/docs/docs/architecture/adr/2026-03-30-k8s-server-side-pagination.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0018: Cluster Manager K8s API에 Server-Side Pagination 및 Namespace Filtering 도입"
+title: "ADR-0022: Cluster Manager K8s API에 Server-Side Pagination 및 Namespace Filtering 도입"
 description: Cluster Manager의 K8s 클러스터 목록 API에 Kubernetes 네이티브 cursor 기반 pagination과 namespace 필터링을 도입하여 대규모 환경 확장성을 확보하는 아키텍처 결정.
 sidebar_position: 22
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, pagination, k8s, performance, cluster-manager, filtering]
 last_updated: 2026-03-30
 ---
 
-# ADR-0018: Cluster Manager K8s API에 Server-Side Pagination 및 Namespace Filtering 도입
+# ADR-0022: Cluster Manager K8s API에 Server-Side Pagination 및 Namespace Filtering 도입
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-pause-resume-status-condition.md
+++ b/docs/docs/architecture/adr/2026-03-30-pause-resume-status-condition.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0018: ACKO Pause/Resume 상태 전환 시 Status Condition 정합성 보장"
+title: "ADR-0023: ACKO Pause/Resume 상태 전환 시 Status Condition 정합성 보장"
 description: ACKO operator의 Pause/Resume 상태 전환 시 Status Condition 불일치 문제를 해결하기 위해 원자적 업데이트와 Resume condition 리셋을 도입하는 아키텍처 결정.
 sidebar_position: 23
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, acko, kubernetes, pause, resume, status-condition, reconciliation]
 last_updated: 2026-03-30
 ---
 
-# ADR-0018: ACKO Pause/Resume 상태 전환 시 Status Condition 정합성 보장
+# ADR-0023: ACKO Pause/Resume 상태 전환 시 Status Condition 정합성 보장
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-pod-readiness-watch.md
+++ b/docs/docs/architecture/adr/2026-03-30-pod-readiness-watch.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0020: ACKO Pod Readiness Watch 전환 및 Status Enrichment 병렬화"
+title: "ADR-0035: ACKO Pod Readiness Watch 전환 및 Status Enrichment 병렬화"
 description: ACKO의 Pod readiness 확인을 10초 간격 polling에서 Kubernetes Informer watch로 전환하고, status enrichment의 Aerospike 노드 정보 수집을 병렬화하여 reconciliation 성능을 개선하는 아키텍처 결정.
 sidebar_position: 35
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, acko, kubernetes, performance, watch, informer, parallelization, rec
 last_updated: 2026-03-30
 ---
 
-# ADR-0020: ACKO Pod Readiness Watch 전환 및 Status Enrichment 병렬화
+# ADR-0035: ACKO Pod Readiness Watch 전환 및 Status Enrichment 병렬화
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-record-count-accuracy.md
+++ b/docs/docs/architecture/adr/2026-03-30-record-count-accuracy.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0019: Cluster Manager 레코드 카운트 정확도 개선"
+title: "ADR-0026: Cluster Manager 레코드 카운트 정확도 개선"
 description: Cluster Manager에서 set object count 조회 실패 시 0 대신 None을 반환하여 "알 수 없음" 상태를 명시적으로 표현하고, 프론트엔드 pagination 정상 동작을 보장하는 아키텍처 결정.
 sidebar_position: 26
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, cluster-manager, record-browser, pagination, api-schema, bug-fix]
 last_updated: 2026-03-30
 ---
 
-# ADR-0019: Cluster Manager 레코드 카운트 정확도 개선
+# ADR-0026: Cluster Manager 레코드 카운트 정확도 개선
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-structured-result-code.md
+++ b/docs/docs/architecture/adr/2026-03-30-structured-result-code.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0019: aerospike-py 구조화된 에러 코드(result_code) 체계 도입"
+title: "ADR-0027: aerospike-py 구조화된 에러 코드(result_code) 체계 도입"
 description: aerospike-py의 모든 AerospikeError 하위 예외에 result_code 정수 속성을 추가하여, 문자열 매칭 대신 안정적인 정수 코드 기반 에러 분류를 지원하는 아키텍처 결정.
 sidebar_position: 27
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, error-handling, result-code, aerospike-py, observability]
 last_updated: 2026-03-30
 ---
 
-# ADR-0019: aerospike-py 구조화된 에러 코드(result_code) 체계 도입
+# ADR-0027: aerospike-py 구조화된 에러 코드(result_code) 체계 도입
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-tokio-worker-autotuning.md
+++ b/docs/docs/architecture/adr/2026-03-30-tokio-worker-autotuning.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0018: aerospike-py Tokio Runtime Worker Thread 자동 튜닝 및 성능 프로파일링"
+title: "ADR-0024: aerospike-py Tokio Runtime Worker Thread 자동 튜닝 및 성능 프로파일링"
 description: aerospike-py의 Tokio runtime worker thread 수를 CPU 코어 기반 heuristic으로 자동 결정하고, RuntimeMetrics를 Prometheus 메트릭으로 노출하는 아키텍처 결정.
 sidebar_position: 24
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, tokio, runtime, performance, metrics, aerospike-py, profiling]
 last_updated: 2026-03-30
 ---
 
-# ADR-0018: aerospike-py Tokio Runtime Worker Thread 자동 튜닝 및 성능 프로파일링
+# ADR-0024: aerospike-py Tokio Runtime Worker Thread 자동 튜닝 및 성능 프로파일링
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-validation-error-circuit-breaker.md
+++ b/docs/docs/architecture/adr/2026-03-30-validation-error-circuit-breaker.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0019: ACKO ValidationError 기반 영구/일시적 오류 분류로 Circuit Breaker 불필요 재시도 방지"
+title: "ADR-0028: ACKO ValidationError 기반 영구/일시적 오류 분류로 Circuit Breaker 불필요 재시도 방지"
 description: ACKO의 기존 ValidationError 타입을 활용하여 영구적 오류를 즉시 식별하고 Circuit Breaker를 즉시 활성화함으로써 불필요한 재시도를 방지하는 아키텍처 결정.
 sidebar_position: 28
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, acko, kubernetes, reconciliation, circuit-breaker, validation, error
 last_updated: 2026-03-30
 ---
 
-# ADR-0019: ACKO ValidationError 기반 영구/일시적 오류 분류로 Circuit Breaker 불필요 재시도 방지
+# ADR-0028: ACKO ValidationError 기반 영구/일시적 오류 분류로 Circuit Breaker 불필요 재시도 방지
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-virtual-scroll-record-browser.md
+++ b/docs/docs/architecture/adr/2026-03-30-virtual-scroll-record-browser.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0017: Cluster Manager 레코드 브라우저 가상 스크롤 도입"
+title: "ADR-0020: Cluster Manager 레코드 브라우저 가상 스크롤 도입"
 description: Cluster Manager 레코드 브라우저에 TanStack Virtual 기반 가상 스크롤을 도입하여 대용량 레코드 렌더링 성능을 개선하는 아키텍처 결정.
 sidebar_position: 20
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, virtual-scroll, performance, frontend, cluster-manager, tanstack]
 last_updated: 2026-03-30
 ---
 
-# ADR-0017: Cluster Manager 레코드 브라우저 가상 스크롤 도입
+# ADR-0020: Cluster Manager 레코드 브라우저 가상 스크롤 도입
 
 ## 상태
 

--- a/docs/docs/architecture/adr/2026-03-30-webhook-validation-enhancement.md
+++ b/docs/docs/architecture/adr/2026-03-30-webhook-validation-enhancement.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-0020: ACKO Webhook Validation 강화 — replication-factor, port overlap, batch size 사전 검증"
+title: "ADR-0036: ACKO Webhook Validation 강화 — replication-factor, port overlap, batch size 사전 검증"
 description: ACKO webhook에 replication-factor, 포트 충돌, batch size 검증을 추가하여 런타임 오류를 admission 단계에서 차단하는 아키텍처 결정
 sidebar_position: 36
 scope: single-repo
@@ -8,7 +8,7 @@ tags: [adr, acko, webhook, validation, stabilization]
 last_updated: 2026-03-30
 ---
 
-# ADR-0020: ACKO Webhook Validation 강화 — replication-factor, port overlap, batch size 사전 검증
+# ADR-0036: ACKO Webhook Validation 강화 — replication-factor, port overlap, batch size 사전 검증
 
 ## 상태
 


### PR DESCRIPTION
## Summary

All 20 ADR files dated `2026-03-30-*.md` were authored with the same starting ADR number stamped into the page title and H1 heading — `ADR-0017`, `ADR-0018`, `ADR-0019`, or `ADR-0020` — but `sidebar_position` was assigned sequentially from 17 to 36 and never back-synced into the document number. The result was 19 files where the rendered page title disagreed with the navigation slot.

| Cluster | Files | title-num before | sidebar_position | title-num after |
|---|---|---|---|---|
| 1 | batch-retry-jitter-backoff | 0017 | 17 | 0017 ✓ |
| 2 | circuit-breaker-adaptive-threshold | 0017 | 18 | 0018 |
| 3 | codegen-type-sync | 0017 | 19 | 0019 |
| 4 | virtual-scroll-record-browser | 0017 | 20 | 0020 |
| 5 | graceful-cancellation | 0018 | 21 | 0021 |
| 6 | k8s-server-side-pagination | 0018 | 22 | 0022 |
| 7 | pause-resume-status-condition | 0018 | 23 | 0023 |
| 8 | tokio-worker-autotuning | 0018 | 24 | 0024 |
| 9 | info-batch-aggregation | 0019 | 25 | 0025 |
| 10 | record-count-accuracy | 0019 | 26 | 0026 |
| 11 | structured-result-code | 0019 | 27 | 0027 |
| 12 | validation-error-circuit-breaker | 0019 | 28 | 0028 |
| 13 | asyncclient-connect-leak | 0020 | 29 | 0029 |
| 14 | auth-security-headers | 0020 | 30 | 0030 |
| 15 | clientmanager-per-connection-lock | 0020 | 31 | 0031 |
| 16 | dynamic-config-transaction | 0020 | 32 | 0032 |
| 17 | frontend-resource-leak-prevention | 0020 | 33 | 0033 |
| 18 | health-check-parallel | 0020 | 34 | 0034 |
| 19 | pod-readiness-watch | 0020 | 35 | 0035 |
| 20 | webhook-validation-enhancement | 0020 | 36 | 0036 |

`adr-index.mdx` was already correct — it uses `sidebar_position` as the source of truth — so no index changes are needed.

## Out of scope (separate PR)

Body cross-references inside several of these ADRs still cite the old numbers (e.g. `[ADR-0018: Graceful Cancellation]` should now read ADR-0021). Links continue to work because each citation targets a file path, not a number, but display text drift remains. Splitting that into its own PR keeps this one a mechanical title-only change that can be reviewed at a glance.

## Verification

- [x] `npm --prefix docs run build` succeeds locally (onBrokenLinks=throw is already on)
- [x] Sanity check: for every `2026-03-30-*.md`, `printf '%04d' sidebar_position` now equals the ADR number in both `title:` and `# ADR-` lines