### PR TITLE
docs: bump README "Latest ADR" pointer to ADR-0052 and refresh release matrix date

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docs/docs/
 
 ## Latest ADR
 
-- [ADR-0040: Multi-Cluster Topology and Keycloak OIDC for ACKO + Cluster-Manager](docs/docs/architecture/adr/2026-05-05-multi-cluster-topology-and-keycloak-oidc.md)
+- [ADR-0052: aerospike-py batch_read 병목 프로파일링 — 3-Methodology Cross-Validation + LazyBatchRecords/to_numpy GIL-detach 검증](docs/docs/architecture/adr/2026-05-23-aerospike-py-batch-read-profiling.md)
 
 ## Development
 

--- a/docs/docs/history/releases/release-matrix.md
+++ b/docs/docs/history/releases/release-matrix.md
@@ -13,7 +13,7 @@ tags:
   - compatibility
   - matrix
   - versioning
-last_updated: 2026-05-15
+last_updated: 2026-05-28
 ---
 
 # Release Compatibility Matrix


### PR DESCRIPTION
## Summary

- **README "Latest ADR" pointer was stale.** It still pointed at ADR-0040 (Multi-Cluster Topology + Keycloak OIDC, 2026-05-05). Bumped to ADR-0052 (`aerospike-py batch_read 병목 프로파일링 — 3-Methodology Cross-Validation + LazyBatchRecords/to_numpy GIL-detach 검증`, 2026-05-23), which is the actual latest ADR by date.
- **`docs/docs/history/releases/release-matrix.md` frontmatter `last_updated`** bumped from `2026-05-15` to `2026-05-28` so it reflects the post-ADR-0052 landing date.
- Complements the just-merged #118 — keeps the public-facing README + release-matrix in sync with the ADR set.

## Test plan

- [x] `cd docs && npm install --silent && npm run build` — passes, no broken-link warnings (only the unrelated pre-existing `vscode-languageserver-types` critical-dependency warning).
- [x] Confirmed ADR title matches the file's frontmatter `title:` field exactly.
- [x] Scope held to 2 files / 2 LOC as specified.