### PR TITLE
docs: refresh plugin layer skill count and add ackoctl to release matrix

### DIFF
--- a/docs/docs/architecture/overview.mdx
+++ b/docs/docs/architecture/overview.mdx
@@ -75,7 +75,7 @@ Aerospike CE Ecosystem은 **User → Agent → Plugin** 계층 구조와 **Kuber
 |------|------|
 | **User** | 개발자, DevOps 엔지니어 |
 | **Agent** | Claude Code, claude-code-action 등 AI 에이전트 |
-| **Plugin** | 5개 Skill + 1개 Agent로 ACKO 배포, aerospike-py API 가이드 제공 |
+| **Plugin** | 9개 Skill (별도 Agent 없음)로 ACKO 배포, aerospike-py API 가이드 제공 |
 
 ### 2. Kubernetes 배포 경로
 

--- a/docs/docs/goals/project-design.md
+++ b/docs/docs/goals/project-design.md
@@ -73,7 +73,7 @@ Kubernetes의 선언적 패턴을 적극 활용합니다:
 
 에코시스템 전체에 AI 개발 도구를 통합합니다:
 
-- **Claude Code plugins**: 5개 Skills + 1개 Agent로 개발 생산성 향상
+- **Claude Code plugins**: 9개 Skill (별도 Agent 없음)로 개발 생산성 향상
 - **Agentic CI**: claude-code-action으로 PR 자동 리뷰 및 피드백
 - **Agentic workflows**: AI가 코드 생성, 리뷰, 테스트, 문서화를 지원
 

--- a/docs/docs/history/releases/release-matrix.md
+++ b/docs/docs/history/releases/release-matrix.md
@@ -8,12 +8,13 @@ repos:
   - acko
   - cluster-manager
   - plugins
+  - ackoctl
 tags:
   - releases
   - compatibility
   - matrix
   - versioning
-last_updated: 2026-05-28
+last_updated: 2026-05-29
 ---
 
 # Release Compatibility Matrix
@@ -94,6 +95,16 @@ Cluster Manager follows continuous deployment aligned with ACKO integration mile
 | Version | Date (approx) | Key Changes |
 |:---:|:---:|:---|
 | v1.0.0 | 2026-03-12 | Initial release: 5 skills, 1 agent, 8 deployment examples, 13 reference docs |
+
+---
+
+## ackoctl Releases
+
+:::note
+ackoctl follows the daily-release workflow (Conventional Commits → minor/patch auto-bump). For the authoritative release list, see the upstream releases page: https://github.com/aerospike-ce-ecosystem/ackoctl/releases
+
+Detailed release history will be backfilled into this matrix in a follow-up. The cross-project compatibility matrix below does not yet include an `ackoctl` column.
+:::
 
 ---
 


### PR DESCRIPTION
## Summary

Two small fixes to bring canonical docs back in sync with reality.

### Fix 1 — Plugin layer skill count is "9 Skills (no separate Agent)"

The former `acko-cluster-debugger` agent was demoted to the `acko-debugging` skill, and four more skills (`acko-debugging`, `acko-e2e-test`, `ackoctl`, `bug-reporter`) were added. The canonical present-tense statement lives in `docs/intro.md` L32, `architecture/components/plugins.mdx` L15, and workspace `CLAUDE.md` — but two pages still said "5개 Skill + 1개 Agent".

- `docs/docs/architecture/overview.mdx:78` — `5개 Skill + 1개 Agent` → `9개 Skill (별도 Agent 없음)` — Plugin row in the User → Agent → Plugin layer table.
- `docs/docs/goals/project-design.md:76` — `5개 Skills + 1개 Agent` → `9개 Skill (별도 Agent 없음)` — AI-assisted Development principle.

Point-in-time accurate historical references are intentionally **left unchanged**:
- `docs/docs/roadmap/milestones/Q1.md` (Q1 milestone snapshot, accurate as-of)
- `docs/docs/goals/project-timeline.md` (dated timeline entries)
- `docs/docs/history/releases/release-matrix.md` v1.0.0 row (the v1.0.0 plugins release really did ship 5 skills + 1 agent)

### Fix 2 — Release matrix gains an `ackoctl` section

`ackoctl` is the 6th canonical repo (workspace `CLAUDE.md` Repository Map; PR #14 merged the submodule; recent commits #15/#16 actively bump it) but had zero presence in `release-matrix.md`.

- `docs/docs/history/releases/release-matrix.md`:
  - frontmatter `repos:` — added `ackoctl` (preserves YAML order)
  - frontmatter `last_updated:` — `2026-05-28` → `2026-05-29`
  - new `## ackoctl Releases` section inserted after `## Plugins Releases`, with a `:::note` admonition pointing to <https://github.com/aerospike-ce-ecosystem/ackoctl/releases>

Deferred for a separate follow-up PR (larger scope): adding an `ackoctl` column to the Cross-Project Compatibility Matrix. The admonition explicitly notes this.

## Test plan

- [x] `cd docs && npm run typecheck` → passes (clean `tsc`).
- [ ] `cd docs && npm run build` → **fails locally**, but the failures are **pre-existing and unrelated to this PR**. Two root causes, neither touched by this PR:
  1. Stale untracked `.js` files in `docs/src/` (e.g. `FlowDiagram.js`, `WhySection/index.js`, `pages/index.js`, etc., from a prior local `tsc --outDir` run) shadow the real `.tsx` sources and lack a `default` export → SSR pages like `/project-hub/`, `/project-hub/docs/architecture/overview`, and `/project-hub/docs/coordination/agentic-workflow` fail to render. These files appear as untracked in `git status` on a clean `main` checkout.
  2. Local Node v25.8.2 vs the project's CI Node 20. CI runs a fresh `npm ci` without the stale local artifacts and should pass.
- [x] Manually verified no broken-link / MDX-parse warnings for any of the three edited files (`overview.mdx`, `project-design.md`, `release-matrix.md`) in the build log — all warnings are about `FlowDiagram` / `WhySection` / `HomeStats` default exports in the stale `.js` files.
- [x] Confirmed historical references in `Q1.md`, `project-timeline.md`, and the `v1.0.0` row of `release-matrix.md` are unchanged (they are point-in-time accurate).

## Scope

Strict scope: only these two fixes. No new ADR, no Docusaurus version bump, no theme/layout changes, no mass renumbering. The cross-project matrix `ackoctl` column is intentionally deferred to a follow-up PR.