### PR TITLE
docs: retire acko-cluster-debugger references and align plugin inventory

### DIFF
--- a/docs/docs/coordination/agentic-workflow.mdx
+++ b/docs/docs/coordination/agentic-workflow.mdx
@@ -244,7 +244,7 @@ Core repo main 머지 (path-filtered)
 | aerospike-py | `exception.py`, `exception.pyi`, `lib.rs` | aerospike-py-api |
 | ACKO | `aerospikecluster_types.go`, `aerospikecluster_webhook.go` | acko-deploy, acko-operations, acko-config-reference |
 | ACKO | `types_storage.go`, `types_network.go`, `types_pod.go`, `types_rack.go` | acko-deploy |
-| ACKO | `reconciler_status.go` | acko-operations, acko-cluster-debugger |
+| ACKO | `reconciler_status.go` | acko-operations, acko-debugging |
 | ACKO | `reconciler_restart.go` | acko-operations |
 
 ### Hub Dispatcher 상세

--- a/docs/docs/history/changelog/plugins.md
+++ b/docs/docs/history/changelog/plugins.md
@@ -11,7 +11,7 @@ tags:
   - claude-code
   - skills
   - agent
-last_updated: 2026-03-29
+last_updated: 2026-05-29
 ---
 
 # Plugins Changelog
@@ -29,12 +29,12 @@ aerospike-ce-ecosystem-plugins 릴리스별 변경 사항을 기록합니다.
 - **acko-deploy**: ACKO 기반 Aerospike 클러스터 배포 가이드
 - **acko-operations**: ACKO 클러스터 운영/관리 가이드
 - **acko-config-reference**: Aerospike CE 설정 파라미터 레퍼런스
+- **acko-debugging**: ACKO 클러스터 트러블슈팅 6단계 진단 절차 (기존 `acko-cluster-debugger` Agent를 Skill로 강등)
+- **acko-e2e-test**: ACKO end-to-end 테스트 플레이북 및 릴리스 검증 체크리스트
+- **ackoctl**: cluster-manager CLI 사용 가이드 (connections, records, queries, K8s CR, admin, UDF)
 - **aerospike-py-api**: aerospike-py API 사용 가이드
 - **aerospike-py-fastapi**: aerospike-py + FastAPI 통합 패턴
-
-### Agent
-
-- **acko-cluster-debugger**: ACKO 클러스터 트러블슈팅 자동화 에이전트
+- **bug-reporter**: 에코시스템 버그를 적절한 레포로 라우팅하고 이슈 컨텍스트 작성
 
 ### 벤치마크 결과
 

--- a/docs/docs/roadmap/milestones/Q1.md
+++ b/docs/docs/roadmap/milestones/Q1.md
@@ -158,8 +158,7 @@ last_updated: 2026-03-29
 
 | 항목 | 상태 | 비고 |
 |------|:---:|------|
-| 5개 Skills | Done | acko-deploy, acko-operations, acko-config-reference, aerospike-py-api, aerospike-py-fastapi |
-| 1개 Agent | Done | acko-cluster-debugger |
+| 9개 Skills | Done | acko-deploy, acko-operations, acko-config-reference, acko-debugging, acko-e2e-test, ackoctl, aerospike-py-api, aerospike-py-fastapi, bug-reporter |
 | 8개 Deployment examples | Done | 다양한 배포 시나리오 |
 | 13개 Reference documents | Done | 기술 참조 문서 |
 


### PR DESCRIPTION
## Summary

Commit [e26371d](https://github.com/aerospike-ce-ecosystem/project-hub/commit/e26371d) refreshed the plugin layer to the canonical 9-skill inventory (no separate Agent). Three docs still referenced the retired \`acko-cluster-debugger\` Agent or the older 5-skill count; this PR aligns them.

## Canonical plugin inventory (per workspace CLAUDE.md)

| # | Skill |
|---|---|
| 1 | acko-deploy |
| 2 | acko-operations |
| 3 | acko-config-reference |
| 4 | acko-debugging (← formerly the \`acko-cluster-debugger\` Agent) |
| 5 | acko-e2e-test |
| 6 | ackoctl |
| 7 | aerospike-py-api |
| 8 | aerospike-py-fastapi |
| 9 | bug-reporter |

## Changes

| File | Change |
|---|---|
| \`docs/docs/history/changelog/plugins.md\` | \`last_updated\` bumped to 2026-05-29; v1.0.0 section replaced with the full 9-skill inventory; \`### Agent\` subsection removed. |
| \`docs/docs/coordination/agentic-workflow.mdx\` | Skill Impact Advisory row for \`reconciler_status.go\` now points at \`acko-debugging\` (was \`acko-cluster-debugger\`). |
| \`docs/docs/roadmap/milestones/Q1.md\` | "5 Skills + 1 Agent" rows collapsed into a single "9 Skills" row listing every shipped skill. |

## Test plan

- [x] \`npm run build\` (Docusaurus): SUCCESS, only a pre-existing critical-dependency warning from \`vscode-languageserver-types\` (unrelated to this PR).
- [x] No new broken links.
- [x] Verified via grep that no remaining stale \`acko-cluster-debugger\` references exist outside the changelog's historical "renamed from" note.