### PR TITLE
docs: Q3 roadmap rollover + accept operating ADRs

### DIFF
--- a/docs/docs/architecture/adr-index.mdx
+++ b/docs/docs/architecture/adr-index.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 scope: ecosystem
 repos: [aerospike-py, acko, cluster-manager, plugins]
 tags: [adr, architecture, decision-record]
-last_updated: 2026-05-23
+last_updated: 2026-07-17
 ---
 
 import Tabs from '@theme/Tabs';
@@ -107,18 +107,18 @@ Architecture Decision Record(ADR)는 프로젝트의 중요한 아키텍처 결�
 | [ADR-0035](./adr/2026-03-30-pod-readiness-watch.md) | ACKO Pod Readiness Watch 전환 및 Status Enrichment 병렬화 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="acko" /> |
 | [ADR-0036](./adr/2026-03-30-webhook-validation-enhancement.md) | ACKO Webhook Validation 강화 | 2026-03-30 | <Status status="Proposed" /> | <Repo name="acko" /> |
 | [ADR-0038](./adr/2026-04-05-external-network-access.md) | 외부 네트워크 접근 — Per-pod LB/NodePort | 2026-04-05 | <Status status="Accepted" /> | <Repo name="acko" /> |
-| [ADR-0039](./adr/2026-04-07-skill-impact-review-pipeline.md) | Skill Impact Review 파이프라인 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
+| [ADR-0039](./adr/2026-04-07-skill-impact-review-pipeline.md) | Skill Impact Review 파이프라인 | 2026-04-07 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
 | [ADR-0040](./adr/2026-05-05-multi-cluster-topology-and-keycloak-oidc.md) | Multi-Cluster Topology and Keycloak OIDC | 2026-05-05 | <Status status="Accepted" /> | <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
 | [ADR-0041](./adr/2026-05-07-mcp-federation-gateway.md) | MCP Federation Gateway | 2026-05-07 | <Status status="Proposed" /> | <Repo name="cluster-manager" /> |
 | [ADR-0042](./adr/2026-05-21-acko-observability-otel-export.md) | ACKO·Cluster Manager OpenTelemetry Export 통합 | 2026-05-21 | <Status status="Accepted" /> | <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="aerospike-py" /> |
-| [ADR-0043](./adr/2026-04-07-ci-workflow-suite-standardization.md) | 에코시스템 통합 CI 워크플로우 스위트 표준화 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
+| [ADR-0043](./adr/2026-04-07-ci-workflow-suite-standardization.md) | 에코시스템 통합 CI 워크플로우 스위트 표준화 | 2026-04-07 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
 | [ADR-0044](./adr/2026-04-07-acko-e2e-expansion-strategy.md) | ACKO E2E 테스트 확장 전략 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="acko" /> |
-| [ADR-0045](./adr/2026-04-07-helm-chart-oci-dual-chart.md) | ACKO Helm Chart 버전 관리 체계 — OCI 이중 Chart | 2026-04-07 | <Status status="Proposed" /> | <Repo name="acko" /> |
-| [ADR-0046](./adr/2026-04-07-otel-tracing-integration.md) | OpenTelemetry Tracing 완전 통합 및 에코시스템 전파 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="cluster-manager" /> |
-| [ADR-0047](./adr/2026-04-07-numpy-batch-memory-model.md) | NumPy Batch 연산 인터페이스 확정 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> |
+| [ADR-0045](./adr/2026-04-07-helm-chart-oci-dual-chart.md) | ACKO Helm Chart 버전 관리 체계 — OCI 이중 Chart | 2026-04-07 | <Status status="Accepted" /> | <Repo name="acko" /> |
+| [ADR-0046](./adr/2026-04-07-otel-tracing-integration.md) | OpenTelemetry Tracing 완전 통합 및 에코시스템 전파 | 2026-04-07 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> <Repo name="cluster-manager" /> |
+| [ADR-0047](./adr/2026-04-07-numpy-batch-memory-model.md) | NumPy Batch 연산 인터페이스 확정 | 2026-04-07 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> |
 | [ADR-0048](./adr/2026-04-07-record-browser-perf-strategy.md) | Record 브라우저 대용량 데이터 통합 성능 전략 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="cluster-manager" /> |
-| [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
-| [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Proposed" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
+| [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
+| [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
 | [ADR-0051](./adr/2026-04-07-daily-release-pipeline.md) | 에코시스템 일일 자동 릴리스 파이프라인 | 2026-04-07 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> <Repo name="acko" /> <Repo name="cluster-manager" /> <Repo name="plugins" /> |
 | [ADR-0052](./adr/2026-05-23-aerospike-py-batch-read-profiling.md) | aerospike-py batch_read 병목 프로파일링 — 3-Methodology Cross-Validation | 2026-05-23 | <Status status="Accepted" /> | <Repo name="aerospike-py" /> |
 
@@ -138,13 +138,13 @@ Architecture Decision Record(ADR)는 프로젝트의 중요한 아키텍처 결�
 | [ADR-0027](./adr/2026-03-30-structured-result-code.md) | 구조화된 에러 코드(result_code) 체계 도입 | 2026-03-30 | <Status status="Proposed" /> |
 | [ADR-0029](./adr/2026-03-30-asyncclient-connect-leak.md) | AsyncClient 동시 connect() 연결 누수 방지 | 2026-03-30 | <Status status="Proposed" /> |
 | [ADR-0031](./adr/2026-03-30-clientmanager-per-connection-lock.md) | ClientManager 동시성 결함 및 per-connection lock | 2026-03-30 | <Status status="Proposed" /> |
-| [ADR-0039](./adr/2026-04-07-skill-impact-review-pipeline.md) | Skill Impact Review 파이프라인 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0039](./adr/2026-04-07-skill-impact-review-pipeline.md) | Skill Impact Review 파이프라인 | 2026-04-07 | <Status status="Accepted" /> |
 | [ADR-0042](./adr/2026-05-21-acko-observability-otel-export.md) | ACKO·Cluster Manager OpenTelemetry Export 통합 | 2026-05-21 | <Status status="Accepted" /> |
-| [ADR-0043](./adr/2026-04-07-ci-workflow-suite-standardization.md) | 에코시스템 통합 CI 워크플로우 스위트 표준화 | 2026-04-07 | <Status status="Proposed" /> |
-| [ADR-0046](./adr/2026-04-07-otel-tracing-integration.md) | OpenTelemetry Tracing 완전 통합 | 2026-04-07 | <Status status="Proposed" /> |
-| [ADR-0047](./adr/2026-04-07-numpy-batch-memory-model.md) | NumPy Batch 연산 인터페이스 확정 | 2026-04-07 | <Status status="Proposed" /> |
-| [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Proposed" /> |
-| [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0043](./adr/2026-04-07-ci-workflow-suite-standardization.md) | 에코시스템 통합 CI 워크플로우 스위트 표준화 | 2026-04-07 | <Status status="Accepted" /> |
+| [ADR-0046](./adr/2026-04-07-otel-tracing-integration.md) | OpenTelemetry Tracing 완전 통합 | 2026-04-07 | <Status status="Accepted" /> |
+| [ADR-0047](./adr/2026-04-07-numpy-batch-memory-model.md) | NumPy Batch 연산 인터페이스 확정 | 2026-04-07 | <Status status="Accepted" /> |
+| [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Accepted" /> |
+| [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Accepted" /> |
 | [ADR-0051](./adr/2026-04-07-daily-release-pipeline.md) | 에코시스템 일일 자동 릴리스 파이프라인 | 2026-04-07 | <Status status="Accepted" /> |
 | [ADR-0052](./adr/2026-05-23-aerospike-py-batch-read-profiling.md) | aerospike-py batch_read 병목 프로파일링 | 2026-05-23 | <Status status="Accepted" /> |
 
@@ -168,14 +168,14 @@ Architecture Decision Record(ADR)는 프로젝트의 중요한 아키텍처 결�
 | [ADR-0035](./adr/2026-03-30-pod-readiness-watch.md) | ACKO Pod Readiness Watch 전환 | 2026-03-30 | <Status status="Proposed" /> |
 | [ADR-0036](./adr/2026-03-30-webhook-validation-enhancement.md) | ACKO Webhook Validation 강화 | 2026-03-30 | <Status status="Proposed" /> |
 | [ADR-0038](./adr/2026-04-05-external-network-access.md) | 외부 네트워크 접근 — Per-pod LB/NodePort | 2026-04-05 | <Status status="Accepted" /> |
-| [ADR-0039](./adr/2026-04-07-skill-impact-review-pipeline.md) | Skill Impact Review 파이프라인 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0039](./adr/2026-04-07-skill-impact-review-pipeline.md) | Skill Impact Review 파이프라인 | 2026-04-07 | <Status status="Accepted" /> |
 | [ADR-0040](./adr/2026-05-05-multi-cluster-topology-and-keycloak-oidc.md) | Multi-Cluster Topology and Keycloak OIDC | 2026-05-05 | <Status status="Accepted" /> |
 | [ADR-0042](./adr/2026-05-21-acko-observability-otel-export.md) | ACKO·Cluster Manager OpenTelemetry Export 통합 | 2026-05-21 | <Status status="Accepted" /> |
-| [ADR-0043](./adr/2026-04-07-ci-workflow-suite-standardization.md) | 에코시스템 통합 CI 워크플로우 스위트 표준화 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0043](./adr/2026-04-07-ci-workflow-suite-standardization.md) | 에코시스템 통합 CI 워크플로우 스위트 표준화 | 2026-04-07 | <Status status="Accepted" /> |
 | [ADR-0044](./adr/2026-04-07-acko-e2e-expansion-strategy.md) | ACKO E2E 테스트 확장 전략 | 2026-04-07 | <Status status="Proposed" /> |
-| [ADR-0045](./adr/2026-04-07-helm-chart-oci-dual-chart.md) | ACKO Helm Chart 버전 관리 체계 | 2026-04-07 | <Status status="Proposed" /> |
-| [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Proposed" /> |
-| [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0045](./adr/2026-04-07-helm-chart-oci-dual-chart.md) | ACKO Helm Chart 버전 관리 체계 | 2026-04-07 | <Status status="Accepted" /> |
+| [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Accepted" /> |
+| [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Accepted" /> |
 | [ADR-0051](./adr/2026-04-07-daily-release-pipeline.md) | 에코시스템 일일 자동 릴리스 파이프라인 | 2026-04-07 | <Status status="Accepted" /> |
 
   </TabItem>
@@ -197,15 +197,15 @@ Architecture Decision Record(ADR)는 프로젝트의 중요한 아키텍처 결�
 | [ADR-0030](./adr/2026-03-30-auth-security-headers.md) | API 인증/인가 및 보안 헤더 강화 | 2026-03-30 | <Status status="Proposed" /> |
 | [ADR-0033](./adr/2026-03-30-frontend-resource-leak-prevention.md) | Frontend 리소스 누수 방지 | 2026-03-30 | <Status status="Proposed" /> |
 | [ADR-0034](./adr/2026-03-30-health-check-parallel.md) | Health Check 병렬화 | 2026-03-30 | <Status status="Proposed" /> |
-| [ADR-0039](./adr/2026-04-07-skill-impact-review-pipeline.md) | Skill Impact Review 파이프라인 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0039](./adr/2026-04-07-skill-impact-review-pipeline.md) | Skill Impact Review 파이프라인 | 2026-04-07 | <Status status="Accepted" /> |
 | [ADR-0040](./adr/2026-05-05-multi-cluster-topology-and-keycloak-oidc.md) | Multi-Cluster Topology and Keycloak OIDC | 2026-05-05 | <Status status="Accepted" /> |
 | [ADR-0041](./adr/2026-05-07-mcp-federation-gateway.md) | MCP Federation Gateway | 2026-05-07 | <Status status="Proposed" /> |
 | [ADR-0042](./adr/2026-05-21-acko-observability-otel-export.md) | ACKO·Cluster Manager OpenTelemetry Export 통합 | 2026-05-21 | <Status status="Accepted" /> |
-| [ADR-0043](./adr/2026-04-07-ci-workflow-suite-standardization.md) | 에코시스템 통합 CI 워크플로우 스위트 표준화 | 2026-04-07 | <Status status="Proposed" /> |
-| [ADR-0046](./adr/2026-04-07-otel-tracing-integration.md) | OpenTelemetry Tracing 완전 통합 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0043](./adr/2026-04-07-ci-workflow-suite-standardization.md) | 에코시스템 통합 CI 워크플로우 스위트 표준화 | 2026-04-07 | <Status status="Accepted" /> |
+| [ADR-0046](./adr/2026-04-07-otel-tracing-integration.md) | OpenTelemetry Tracing 완전 통합 | 2026-04-07 | <Status status="Accepted" /> |
 | [ADR-0048](./adr/2026-04-07-record-browser-perf-strategy.md) | Record 브라우저 대용량 데이터 성능 전략 | 2026-04-07 | <Status status="Proposed" /> |
-| [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Proposed" /> |
-| [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Proposed" /> |
+| [ADR-0049](./adr/2026-04-07-adr-lifecycle-automation.md) | Project Hub ADR Lifecycle 자동화 아키텍처 | 2026-04-07 | <Status status="Accepted" /> |
+| [ADR-0050](./adr/2026-04-07-dependency-chain-merge-order.md) | 에코시스템 의존성 체인 및 Merge 순서 원칙 | 2026-04-07 | <Status status="Accepted" /> |
 | [ADR-0051](./adr/2026-04-07-daily-release-pipeline.md) | 에코시스템 일일 자동 릴리스 파이프라인 | 2026-04-07 | <Status status="Accepted" /> |
 
   </TabItem>

--- a/docs/docs/architecture/adr/2026-04-07-adr-lifecycle-automation.md
+++ b/docs/docs/architecture/adr/2026-04-07-adr-lifecycle-automation.md
@@ -5,16 +5,17 @@ sidebar_position: 49
 scope: ecosystem
 repos: [aerospike-py, acko, cluster-manager, plugins]
 tags: [adr, automation, issueops, ai-review, workflow, dispatch]
-last_updated: 2026-04-07
+last_updated: 2026-07-17
 ---
 
 # ADR-0049: Project Hub ADR Lifecycle 자동화 아키텍처 — 리뷰/디스패치/상태 관리 3단계 자동화
 
 ## 상태
 
-**Proposed**
+**Accepted**
 
 - 제안일: 2026-04-07
+- 승인일: 2026-07-17
 - 관련 이슈: aerospike-ce-ecosystem/project-hub#54
 - 검토 결과: POSITIVE REVIEW
 

--- a/docs/docs/architecture/adr/2026-04-07-ci-workflow-suite-standardization.md
+++ b/docs/docs/architecture/adr/2026-04-07-ci-workflow-suite-standardization.md
@@ -5,16 +5,17 @@ sidebar_position: 43
 scope: ecosystem
 repos: [aerospike-py, acko, cluster-manager, plugins]
 tags: [adr, ci, workflow, standardization, automation, claude-code-action]
-last_updated: 2026-04-07
+last_updated: 2026-07-17
 ---
 
 # ADR-0043: 에코시스템 통합 CI 워크플로우 스위트 표준화
 
 ## 상태
 
-**Proposed**
+**Accepted**
 
 - 제안일: 2026-04-07
+- 승인일: 2026-07-17
 - 관련 이슈: aerospike-ce-ecosystem/project-hub#48
 - 검토 결과: POSITIVE REVIEW
 

--- a/docs/docs/architecture/adr/2026-04-07-dependency-chain-merge-order.md
+++ b/docs/docs/architecture/adr/2026-04-07-dependency-chain-merge-order.md
@@ -5,16 +5,17 @@ sidebar_position: 50
 scope: ecosystem
 repos: [aerospike-py, aerospike-ce-kubernetes-operator, aerospike-cluster-manager, aerospike-ce-ecosystem-plugins]
 tags: [adr, dependency-chain, merge-order, cross-repo, ci, release]
-last_updated: 2026-04-07
+last_updated: 2026-07-17
 ---
 
 # ADR-0050: 에코시스템 의존성 체인 및 Merge 순서 원칙
 
 ## 상태
 
-**Proposed**
+**Accepted**
 
 - 제안일: 2026-04-07
+- 승인일: 2026-07-17
 - 관련 이슈: aerospike-ce-ecosystem/project-hub#56
 - 검토 결과: POSITIVE REVIEW
 

--- a/docs/docs/architecture/adr/2026-04-07-helm-chart-oci-dual-chart.md
+++ b/docs/docs/architecture/adr/2026-04-07-helm-chart-oci-dual-chart.md
@@ -5,16 +5,17 @@ sidebar_position: 45
 scope: single-repo
 repos: [acko]
 tags: [adr, acko, helm, oci, crd, versioning, kubernetes]
-last_updated: 2026-04-07
+last_updated: 2026-07-17
 ---
 
 # ADR-0045: ACKO Helm Chart 버전 관리 체계 — OCI Registry 기반 CRD/Operator 이중 Chart 릴리스
 
 ## 상태
 
-**Proposed**
+**Accepted**
 
 - 제안일: 2026-04-07
+- 승인일: 2026-07-17
 - 관련 이슈: aerospike-ce-ecosystem/project-hub#49
 - 검토 결과: POSITIVE REVIEW
 

--- a/docs/docs/architecture/adr/2026-04-07-numpy-batch-memory-model.md
+++ b/docs/docs/architecture/adr/2026-04-07-numpy-batch-memory-model.md
@@ -5,16 +5,17 @@ sidebar_position: 47
 scope: single-repo
 repos: [aerospike-py]
 tags: [adr, numpy, batch, memory-model, pyo3, aerospike-py, zero-copy]
-last_updated: 2026-04-07
+last_updated: 2026-07-17
 ---
 
 # ADR-0047: NumPy Batch 연산 인터페이스 확정 — Owned Arrays 기본 메모리 모델
 
 ## 상태
 
-**Proposed**
+**Accepted**
 
 - 제안일: 2026-04-07
+- 승인일: 2026-07-17
 - 관련 이슈: aerospike-ce-ecosystem/project-hub#52
 - 검토 결과: POSITIVE REVIEW
 

--- a/docs/docs/architecture/adr/2026-04-07-otel-tracing-integration.md
+++ b/docs/docs/architecture/adr/2026-04-07-otel-tracing-integration.md
@@ -5,16 +5,17 @@ sidebar_position: 46
 scope: ecosystem
 repos: [aerospike-py, cluster-manager]
 tags: [adr, opentelemetry, tracing, observability, prometheus]
-last_updated: 2026-04-07
+last_updated: 2026-07-17
 ---
 
 # ADR-0046: OpenTelemetry Tracing 완전 통합 및 에코시스템 전파
 
 ## 상태
 
-**Proposed**
+**Accepted**
 
 - 제안일: 2026-04-07
+- 승인일: 2026-07-17
 - 관련 이슈: aerospike-ce-ecosystem/project-hub#50
 - 검토 결과: POSITIVE REVIEW
 

--- a/docs/docs/architecture/adr/2026-04-07-skill-impact-review-pipeline.md
+++ b/docs/docs/architecture/adr/2026-04-07-skill-impact-review-pipeline.md
@@ -5,16 +5,17 @@ sidebar_position: 39
 scope: ecosystem
 repos: [aerospike-py, acko, cluster-manager, plugins]
 tags: [adr, automation, cross-repo, skill-sync, pipeline, claude-code-action]
-last_updated: 2026-04-07
+last_updated: 2026-07-17
 ---
 
 # ADR-0039: Skill Impact Review 파이프라인 — Core Repo → Plugin Skill 변경 감지 및 자동 디스패치
 
 ## 상태
 
-**Proposed**
+**Accepted**
 
 - 제안일: 2026-04-07
+- 승인일: 2026-07-17
 - 관련 이슈: aerospike-ce-ecosystem/project-hub#47
 - 검토 결과: POSITIVE REVIEW
 

--- a/docs/docs/roadmap/current.md
+++ b/docs/docs/roadmap/current.md
@@ -1,6 +1,6 @@
 ---
-title: 현재 분기 목표 (2026-Q2)
-description: Aerospike CE Ecosystem 2026년 2분기 개발 목표 및 우선순위
+title: 현재 분기 목표 (2026-Q3)
+description: Aerospike CE Ecosystem 2026년 3분기 개발 목표 및 우선순위
 sidebar_position: 1
 scope: ecosystem
 repos:
@@ -10,15 +10,15 @@ repos:
   - plugins
 tags:
   - roadmap
-  - q2-2026
+  - q3-2026
   - goals
   - planning
-last_updated: 2026-05-23
+last_updated: 2026-07-17
 ---
 
-# 2026-Q2 목표
+# 2026-Q3 목표
 
-2026년 2분기(4월~6월) Aerospike CE Ecosystem 각 프로젝트별 개발 목표입니다.
+2026년 3분기(7월~9월) Aerospike CE Ecosystem 각 프로젝트별 개발 목표입니다. Q2가 운영 안정화·성능·에코시스템 자동화 명문화에 집중했다면([Q2 회고](./milestones/Q2.md) 참고), Q3는 **cross-repo 계약 정합화, UI/toolchain 현대화, Q2 미완료 항목 완성**에 집중합니다.
 
 ---
 
@@ -26,9 +26,8 @@ last_updated: 2026-05-23
 
 | 목표 | 설명 |
 |------|------|
-| batch_write retry 구현 | `batch_write(..., retry=N)` 옵션으로 client side에서 실패 제어 |
-| NumPy batch 연산 안정화 | `batch_read_numpy`, `batch_write_numpy` 스펙 안정화 및 엣지 케이스 해결 |
-| OpenTelemetry tracing 통합 | Distributed tracing 연동으로 Observability 강화 |
+| 구조화된 result_code 예외 속성 도입 완료 | ADR-0027 기반으로 예외 객체에 `result_code` 등 구조화된 속성을 노출하고, cluster-manager backend와 연동하여 에러 분류·처리를 일관화 |
+| aerospike-core v3 stable 추적 및 채택 평가 | 현재 `aerospike-core` v2.0.0 사용. v3 stable 릴리스 추적 및 채택 시 영향(API/성능/breaking change) 평가 |
 
 ---
 
@@ -36,8 +35,8 @@ last_updated: 2026-05-23
 
 | 목표 | 설명 |
 |------|------|
-| E2E 테스트 확장 | Scale, rolling update, ACL 등 운영 시나리오 Kind 기반 E2E 테스트 추가 |
-| Helm chart 버전 관리 체계화 | 릴리스 프로세스 정립 및 chart 버전 관리 자동화 |
+| E2E 테스트 확장 (Q2 carry forward) | ADR-0044 확정 전략에 따라 scale/rolling update/ACL/dynamic config 등 시나리오별 독립 테스트 스위트와 CI matrix 병렬 실행 구현 |
+| Go 모듈 경로 org 네임스페이스 정합화 | `go.mod` 모듈 경로를 org 네임스페이스(`github.com/aerospike-ce-ecosystem/...`)로 정합화하고 import 경로 일괄 갱신 |
 
 ---
 
@@ -45,8 +44,9 @@ last_updated: 2026-05-23
 
 | 목표 | 설명 |
 |------|------|
-| Record 브라우저 대용량 데이터 성능 최적화 | Scan/query 시 limit, pagination, timeout 제어로 대용량 데이터셋 안정성 확보 |
-| ACKO 클러스터 생성 Wizard UX 개선 | Wizard 기반 생성 흐름의 편의성 및 UX 개선 |
+| UI 스택 현대화 | Next.js 15, ESLint 9, CopilotKit v2 등으로 프론트엔드 toolchain 업그레이드 및 마이그레이션 |
+| Record 브라우저 성능 전략 완성 (Q2 carry forward) | ADR-0048에 따라 cursor 기반 pagination(기본 모드) + virtual scroll/streaming(탐색 모드) + 3계층 timeout 통합을 구현 |
+| result_code 연동 | aerospike-py 구조화된 result_code 예외 속성을 backend 에러 처리에 반영 (ADR-0027) |
 
 ---
 
@@ -54,15 +54,15 @@ last_updated: 2026-05-23
 
 | 목표 | 설명 |
 |------|------|
-| Skills 최신 API 반영 | aerospike-py API 변경, ACKO CRD 변경 등 최신 사항 반영 |
-| acko-debugging 정확도 개선 | 실제 트러블슈팅 시나리오에서의 디버깅 정확도 향상 |
+| Skill 동기화 자동화 지속 | Skill Impact Review 파이프라인(ADR-0039)을 유지하며 core repo API/CRD 변경을 skill에 지속 반영 |
+| Skills 정확도 개선 | result_code·UI 스택 변경 등 Q3 변경 사항을 반영하고 skill 트리거/내용 정확도 개선 |
 
 ---
 
-## project-hub
+## project-hub / 에코시스템 위생
 
 | 목표 | 설명 |
 |------|------|
-| 인터랙티브 다이어그램 고도화 | ReactFlow 다이어그램 dark mode 지원, 노드 검색/필터 기능 |
-| PR 히스토리 자동화 | GitHub API 연동으로 PR 히스토리 자동 수집 및 문서 생성 |
-| 릴리스 호환성 매트릭스 자동화 | 각 레포 릴리스 시 호환성 매트릭스 자동 업데이트 |
+| CI/유지보수 위생 | GitHub Actions 버전 정렬, 워크플로우 스위트(ADR-0043) 정합성 유지, 공유 설정 표준 점검 |
+| ADR 상태 정합화 | 운영 중인 시스템을 반영하도록 ADR 상태(Proposed→Accepted) 및 lifecycle 자동화(ADR-0049) 유지 |
+| 릴리스 호환성 매트릭스 보강 | Release Compatibility Matrix에 Q3 릴리스 반영 및 ackoctl 컬럼 backfill |

--- a/docs/docs/roadmap/milestones/Q2.md
+++ b/docs/docs/roadmap/milestones/Q2.md
@@ -1,0 +1,141 @@
+---
+title: 2026-Q2 회고
+description: Aerospike CE Ecosystem 2026년 2분기 마일스톤 회고
+sidebar_position: 2
+scope: ecosystem
+repos:
+  - aerospike-py
+  - acko
+  - cluster-manager
+  - plugins
+tags:
+  - milestone
+  - retrospective
+  - q2-2026
+last_updated: 2026-07-17
+---
+
+# 2026-Q2 회고
+
+2026년 2분기(4월~6월) 마일스톤 달성 현황을 정리합니다. Q1에서 완성한 에코시스템 기초 위에서, Q2는 **운영 안정화·성능·에코시스템 자동화**에 집중했습니다. 이 문서는 [Q2 로드맵](../current.md)에서 정의한 목표별 달성 현황과, 로드맵에는 없었으나 Q2 중 추가로 진행된 항목을 함께 정리합니다.
+
+각 항목의 근거는 [Release Compatibility Matrix](../../history/releases/release-matrix.md)의 버전 이력과, 2분기에 기록된 ADR([ADR 목록](../../architecture/adr-index.mdx))입니다.
+
+---
+
+## Q2 로드맵 목표 달성 현황
+
+### aerospike-py
+
+| 목표 | 상태 | 비고 |
+|------|:---:|------|
+| batch_write retry 구현 | Done | `batch_write(..., retry=N)` client-side retry (Q1 말 도입, Q2 안정화) |
+| NumPy batch 연산 안정화 | Done | Owned Arrays 메모리 모델로 인터페이스 확정 (ADR-0047) |
+| OpenTelemetry tracing 통합 | Done | PyO3 경계 W3C trace context 전파 완성, opt-in 설계 (ADR-0046) |
+
+### ACKO
+
+| 목표 | 상태 | 비고 |
+|------|:---:|------|
+| E2E 테스트 확장 | In progress | 전략은 ADR-0044로 확정(Proposed), 시나리오별 스위트·CI matrix 구현은 Q3로 carry forward |
+| Helm chart 버전 관리 체계화 | Done | OCI Registry 기반 CRD/Operator 이중 chart 릴리스 (ADR-0045) |
+
+### cluster-manager
+
+| 목표 | 상태 | 비고 |
+|------|:---:|------|
+| Record 브라우저 대용량 데이터 성능 최적화 | Partial | `MAX_QUERY_RECORDS` 하드 리밋·timeout·기본 pagination은 반영. cursor pagination·virtual scroll·streaming 통합 전략(ADR-0048, Proposed)은 Q3로 carry forward |
+| ACKO 클러스터 생성 Wizard UX 개선 | Done | 5-step wizard 흐름 개선 지속 |
+
+### plugins
+
+| 목표 | 상태 | 비고 |
+|------|:---:|------|
+| Skills 최신 API 반영 | Done (ongoing) | Skill Impact Review 파이프라인으로 core repo 변경을 자동 감지·반영 (ADR-0039) |
+| acko-debugging 정확도 개선 | Done | 디버깅 skill 정비 및 plugin inventory 정리(acko-cluster-debugger 참조 정리) |
+
+### project-hub
+
+| 목표 | 상태 | 비고 |
+|------|:---:|------|
+| 인터랙티브 다이어그램 고도화 | Done | ReactFlow 다이어그램 유지·개선 |
+| PR 히스토리 자동화 | Done | GitHub API 연동 weekly PR stats 자동 수집 |
+| 릴리스 호환성 매트릭스 자동화 | Partial | Release Compatibility Matrix 유지, 일부 자동화(ackoctl 컬럼 backfill은 미완) |
+
+---
+
+## 주요 릴리스 및 전달 내용
+
+### aerospike-py
+
+**릴리스**: v0.0.5 → v0.2.1 (Release Matrix 기준)
+
+- **batch_write() API 확정** 및 `in_doubt` 필드 노출 (v0.2.0)
+- **aerospike crate v2.0.0** 채택
+- **Full Jitter 기반 exponential backoff**, lifecycle state machine 등 점진적 안정화 (v0.1.x)
+- **NumPy batch 인터페이스 확정** — Owned Arrays를 기본 메모리 모델로 채택 (ADR-0047)
+- **OpenTelemetry Tracing 완성** — Python → Rust → Aerospike 전 경로 distributed tracing, optional dependency(`aerospike-py[otel]`) (ADR-0046)
+- **batch_read 병목 프로파일링** — 3-methodology cross-validation 분석 (ADR-0052)
+
+### ACKO (Aerospike CE Kubernetes Operator)
+
+**릴리스**: v0.1.8 → v0.4.1 (Release Matrix 기준)
+
+- **Dynamic Config Two-Phase Commit** — 부분 적용 방지 트랜잭션 보장 (v0.2.x)
+- **Circuit breaker 강화** 및 **Pod Readiness Watch** 전환 (v0.2.x~v0.3.x)
+- **외부 네트워크 접근** — per-pod LoadBalancer/NodePort, status의 external endpoints 노출 (ADR-0038, v0.4.1)
+- **Helm OCI 이중 Chart 릴리스** — CRD/Operator 독립 chart, GHCR OCI 배포 (ADR-0045)
+- **Multi-Cluster Topology + Keycloak OIDC** 아키텍처 확정 (ADR-0040)
+
+### Cluster Manager
+
+**릴리스**: v0.3.8 → v0.6.1 (Release Matrix 기준)
+
+- **SSE 기반 실시간 이벤트 스트리밍** (v0.5.x)
+- **Health check 병렬화**, **per-connection lock** 도입 (v0.5.x)
+- **K8s server-side pagination**, **보안 헤더 강화**, **virtual scrolling** (v0.6.x)
+- **OpenTelemetry Export 통합** — ACKO·Cluster Manager 관측성 연동, aerospike-py trace 소비 기반 마련 (ADR-0042, ADR-0046)
+- **MCP Federation Gateway** 아키텍처 확정 (ADR-0041)
+
+### plugins
+
+- **Skill Impact Review 파이프라인** 운영 — core repo(aerospike-py, ACKO) 파일 변경을 감지해 project-hub 경유로 skill 영향 이슈를 디스패치 (ADR-0039)
+- Skills를 최신 API/CRD에 지속 동기화, plugin inventory 정리
+
+---
+
+## 에코시스템 자동화 (project-hub 중심)
+
+Q2에는 4개 repo에 걸친 CI/자동화 인프라를 ADR로 명문화하고 표준화했습니다.
+
+| 항목 | ADR | 내용 |
+|------|:---:|------|
+| ADR Lifecycle 자동화 | ADR-0049 | AI 리뷰 → 자동 ADR 생성/디스패치 → 상태 관리 3단계 파이프라인 |
+| CI 워크플로우 스위트 표준화 | ADR-0043 | agent-implement, pr-reviewer, issue-planner, daily-release, skill-impact-notify 적용 범위 표준화 |
+| 일일 자동 릴리스 파이프라인 | ADR-0051 | Conventional Commits 기반 minor/patch 자동 릴리스 |
+| 의존성 체인 및 Merge 순서 원칙 | ADR-0050 | aerospike-py → ACKO → cluster-manager → plugins 순서 공식화 |
+| Skill Impact Review 파이프라인 | ADR-0039 | Core repo 변경의 skill 영향 자동 감지·디스패치 |
+
+---
+
+## 종합 평가
+
+### 주요 성과
+
+1. **운영 안정화**: aerospike-py·ACKO·cluster-manager 모두 v0.2~v0.6대의 안정 릴리스로 진입하며 운영 시나리오 대응력을 강화
+2. **성능 및 관측성**: OpenTelemetry distributed tracing을 aerospike-py에서 cluster-manager까지 전파하고, batch_read 병목을 정량 분석
+3. **에코시스템 자동화 명문화**: ADR lifecycle, CI 스위트, daily-release, 의존성 체인, skill-impact 파이프라인을 ADR로 표준화하여 cross-repo 관리 체계 확립
+4. **CE 운영 기능 확장**: ACKO external access, dynamic config 트랜잭션, multi-cluster/OIDC 등 실제 운영에 필요한 기능 확충
+
+### 미완료 / Q3 carry forward
+
+- **ACKO E2E 테스트 확장** (ADR-0044): 시나리오별 독립 스위트 + CI matrix 병렬 실행 구현
+- **Record 브라우저 대용량 데이터 통합 성능 전략** (ADR-0048): cursor pagination(기본 모드) + virtual scroll/streaming(탐색 모드) + 3계층 timeout 통합
+- **릴리스 매트릭스 자동화**: ackoctl 컬럼 backfill 등 자동화 잔여 작업
+
+### Q3 방향
+
+- aerospike-py: 구조화된 result_code 예외 속성 도입 완료 및 cluster-manager 연동, aerospike-core v3 stable 추적·채택 평가
+- ACKO: E2E 시나리오 확장 실행, Go 모듈 경로 org 네임스페이스 정합화
+- Cluster Manager: UI 스택 현대화(Next 15, ESLint 9, CopilotKit v2), record 브라우저 성능 전략 완성
+- 에코시스템: CI/유지보수 위생(skill 동기화 자동화 지속, GitHub Actions 버전 정렬)

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -42,7 +42,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'category',
           label: 'Milestones',
-          items: ['roadmap/milestones/Q1'],
+          items: ['roadmap/milestones/Q1', 'roadmap/milestones/Q2'],
         },
       ],
     },


### PR DESCRIPTION
## Task A — ADR status fixes (Item 5)

Verified each 2026-04-07 ADR against the actual workspace checkouts (aerospike-py, ACKO, cluster-manager, plugins, project-hub) and repo workflows. Flipped only the ones confirmed live to **Accepted** (added `- 승인일: 2026-07-17`, bumped frontmatter `last_updated`), and mirrored the status badges in `adr-index.mdx`.

| ADR | Issue | Verdict | Evidence |
|-----|-------|---------|----------|
| ADR-0039 skill-impact-review-pipeline | project-hub#47 | ✅ Accepted | `skill-impact-notify.yml` in aerospike-py + ACKO; `hub-issue-planner.yml` + `hub-issue-dispatcher.yml` live in project-hub |
| ADR-0043 ci-workflow-suite-standardization | project-hub#48 | ✅ Accepted | agent-implement / pr-reviewer / issue-planner / daily-release / skill-impact-notify present across repos (plugins daily-release gap now closed) |
| ADR-0045 helm-chart-oci-dual-chart | project-hub#49 | ✅ Accepted | ACKO `publish-chart.yml` packages+pushes `…-crds` and operator charts to `oci://ghcr.io/…/charts` with `file://`→`oci://` transition; both charts exist |
| ADR-0046 otel-tracing-integration | project-hub#50 | ✅ Accepted | aerospike-py `rust/src/tracing.rs` W3C trace context across PyO3 boundary + `_observability.py` init + `otel` optional dep; cluster-manager api depends on `aerospike-py[otel]` + full OTel SDK/exporter/instrumentation + `otel/otel-collector.yaml` |
| ADR-0047 numpy-batch-memory-model | project-hub#52 | ✅ Accepted | `numpy_support.rs` (owned-array copy model), `numpy_batch.py` `NumpyBatchRecords`, `batch_read_numpy`/`batch_write_numpy` public in `.pyi` + Rust client/async_client; `numpy` optional dep |
| ADR-0049 adr-lifecycle-automation | project-hub#54 | ✅ Accepted | `hub-issue-planner.yml` (3-verdict + repo-plan markup), `hub-issue-dispatcher.yml`, `hub-adr-status-override.yml` all live; the ADR docs themselves are products of this pipeline |
| ADR-0050 dependency-chain-merge-order | project-hub#56 | ✅ Accepted | Chain `aerospike-py → ACKO → cluster-manager → plugins` codified in workspace CLAUDE.md and hub planner/dispatcher prompts — reflects current practice |
| ADR-0044 acko-e2e-expansion-strategy | project-hub#51 | ⏸ Proposed | Feature NOT implemented: e2e dir still has only the pre-expansion suites (cluster/features/multirack/pvc/template); no dedicated scale/rolling-update/ACL/monitoring/dynamic-config scenario files; `test-e2e.yml` has no `matrix` strategy |
| ADR-0048 record-browser-perf-strategy | project-hub#53 | ⏸ Proposed | Feature NOT implemented: no TanStack Virtual / react-window in UI source, no cursor/digest/partition-filter pagination in `records_service`, no `StreamingResponse` in records router. Only basic limit-based pagination + `MAX_QUERY_RECORDS` cap + generic AbortController exist — not the ADR's dual-mode + 3-layer-timeout architecture |
| ADR-0051 daily-release-pipeline | project-hub#46 | — | Already Accepted; skipped |

**Note:** GitHub issues for flipped ADRs are NOT closed here — orchestrator to close #47, #48, #49, #50, #52, #54, #56.

## Task B — Q3 roadmap rollover (Item 4)

- **Archived Q2** → `docs/docs/roadmap/milestones/Q2.md` as a retrospective mirroring `Q1.md` (frontmatter `title: 2026-Q2 회고`, `sidebar_position: 2`, retrospective tags). Content derived factually from the Release Compatibility Matrix version history and Q2-dated ADRs — goal-by-goal status (done / partial / carry-forward), major releases per project, and the ecosystem-automation ADRs. No invented metrics.
- **Rewrote `current.md` for 2026-Q3** — frontmatter updated (title, description, `q2-2026`→`q3-2026`, `last_updated: 2026-07-17`), goals grounded in actual backlog/carry-forward and phrased in the doc's existing per-project table style:
  - aerospike-py: 구조화된 result_code 예외 속성 도입 완료 + cluster-manager 연동 (ADR-0027); aerospike-core v3 stable 추적·채택 평가 (현재 v2.0.0)
  - cluster-manager: UI 스택 현대화 (Next 15 / ESLint 9 / CopilotKit v2 — 현재 Next 14.2.35 / ESLint 8 / CopilotKit v1); record 브라우저 성능 전략 완성 (ADR-0048 carry-forward)
  - ACKO: Go 모듈 경로 org 네임스페이스 정합화 (현재 `github.com/ksr/…`); E2E 테스트 확장 (ADR-0044 carry-forward)
  - 에코시스템: CI/유지보수 위생 (skill 동기화 자동화 지속, GitHub Actions 버전 정렬)
- Registered `roadmap/milestones/Q2` in `docs/sidebars.ts` (Milestones is a manual list, not autogenerated).

> Scope correction: the orchestrator brief cited "(ADR-0011)" for the structured result_code goal, but ADR-0011 is the CRD rename. The structured `result_code` ADR is **ADR-0027**, which is what the docs reference.

## Verify

- `npm ci && npm run build` — ✅ success, no broken-link errors introduced (`onBrokenLinks: 'throw'`)
- `npm run typecheck` (`tsc`) — ✅ exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)